### PR TITLE
JSON RPC classes

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.mcp-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.mcp-module.gradle
@@ -12,6 +12,8 @@ ossIndexAudit {
         password = ossIndexPassword
     }
 }
+
 micronautBuild {
     binaryCompatibility.enabledAfter("1.0.0")
 }
+

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.mcp-tck-suite.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.mcp-tck-suite.gradle
@@ -1,0 +1,17 @@
+plugins {
+    id("io.micronaut.build.internal.mcp-base")
+    id("java-library")
+}
+
+dependencies {
+    testImplementation(platform(mn.micronaut.core.bom))
+    testImplementation(projects.testSuiteJsonRpcTck)
+    testImplementation(platform(mnTest.micronaut.test.bom))
+    testImplementation(libs.junit.platform.engine)
+    testImplementation(mnTest.junit.jupiter.engine)
+    testRuntimeOnly(mnLogging.logback.classic)
+}
+
+tasks.named("test") {
+    useJUnitPlatform()
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,13 +18,18 @@
 [versions]
 micronaut = "4.9.7"
 micronaut-docs = "2.0.0"
-micronaut-test = "4.6.2"
+micronaut-serde = "2.15.0"
+micronaut-logging = "1.7.0"
+micronaut-test = "4.7.0"
 groovy = "4.0.27"
 spock = "2.3-groovy-4.0"
 sonatype-scan = "3.1.1"
 
 [libraries]
 micronaut-core = { module = 'io.micronaut:micronaut-core-bom', version.ref = 'micronaut' }
+micronaut-serde = { module = 'io.micronaut.serde:micronaut-serde-bom', version.ref = 'micronaut-serde' }
+micronaut-logging = { module = 'io.micronaut.logging:micronaut-logging-bom', version.ref = 'micronaut-logging' }
+junit-platform-engine = { module = "org.junit.platform:junit-platform-suite-engine" }
 
 # Plugins
 sonatype-scan = { module = "org.sonatype.gradle.plugins:scan-gradle-plugin", version.ref = "sonatype-scan" }

--- a/micronaut-json-rpc/build.gradle.kts
+++ b/micronaut-json-rpc/build.gradle.kts
@@ -1,0 +1,18 @@
+import io.micronaut.build.TestFramework
+plugins {
+    id("io.micronaut.build.internal.mcp-module")
+}
+dependencies {
+    implementation(mnSerde.micronaut.serde.api)
+    implementation("com.fasterxml.jackson.core:jackson-annotations")
+    testAnnotationProcessor(mn.micronaut.inject.java)
+    testAnnotationProcessor(mnSerde.micronaut.serde.processor)
+    testImplementation(mnSerde.micronaut.serde.jackson)
+    testRuntimeOnly(mnLogging.logback.classic)
+}
+micronautBuild {
+    testFramework = TestFramework.JUNIT5
+}
+tasks.withType<Test> {
+    useJUnitPlatform()
+}

--- a/micronaut-json-rpc/src/main/java/io/micronaut/mcp/jsonrpc/Error.java
+++ b/micronaut-json-rpc/src/main/java/io/micronaut/mcp/jsonrpc/Error.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.mcp.jsonrpc;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.serde.annotation.Serdeable;
+
+/**
+ * Represents a JSON-RPC Error object as specified by the JSON-RPC specification.
+ *
+ * @param code    A Number that indicates the error type that occurred. This MUST be an integer.
+ * @param message A String providing a short description of the error. SHOULD be concise and a single sentence.
+ * @param data    A Primitive or Structured value that contains additional information about the error. This may be omitted.
+ * @param <T>     The type of additional error information
+ */
+@Serdeable
+public record Error<T> (
+    int code,
+    @NonNull String message,
+    @Nullable T data
+) {
+    public Error(ErrorCode errorCode) {
+        this(errorCode.getCode(), errorCode.getMessage(), null);
+    }
+}

--- a/micronaut-json-rpc/src/main/java/io/micronaut/mcp/jsonrpc/ErrorCode.java
+++ b/micronaut-json-rpc/src/main/java/io/micronaut/mcp/jsonrpc/ErrorCode.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.mcp.jsonrpc;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+
+/**
+ * JSON RPC pre-defined error codes.
+ * @see <a href="https://www.jsonrpc.org/specification">JSON RPC Specification Error Object</a>
+ */
+public enum ErrorCode {
+    PARSE_ERROR(-32700, "Parse error", "Invalid JSON was received by the server. An error occurred on the server while parsing the JSON text."),
+    INVALID_REQUEST(-32600, "Invalid Request", "The JSON sent is not a valid Request object."),
+    METHOD_NOT_FOUND(-32601, "Method not found", "The method does not exist / is not available."),
+    INVALID_PARAMS(-32602, "Invalid params", "Invalid method parameter(s)."),
+    INTERNAL_ERROR(-32603, "Internal error", "Internal JSON-RPC error."),
+    SERVER_ERROR(-32000, "Server error", "Reserved for implementation-defined server-errors."); // Use for -32000 to -32099
+
+    private final int code;
+    @NonNull
+    private final String message;
+
+    @NonNull
+    private final String meaning;
+
+    ErrorCode(int code, String message, String meaning) {
+        this.code = code;
+        this.message = message;
+        this.meaning = meaning;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    @NonNull
+    public String getMessage() {
+        return message;
+    }
+
+    @NonNull
+    public String getMeaning() {
+        return meaning;
+    }
+
+    @Nullable
+    public static ErrorCode of(int code) {
+        for (ErrorCode errorCode : values()) {
+            if (errorCode.code == code) {
+                return errorCode;
+            }
+        }
+        return null;
+    }
+}

--- a/micronaut-json-rpc/src/main/java/io/micronaut/mcp/jsonrpc/ErrorResponse.java
+++ b/micronaut-json-rpc/src/main/java/io/micronaut/mcp/jsonrpc/ErrorResponse.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.mcp.jsonrpc;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.serde.annotation.Serdeable;
+
+/**
+ * JSON-RPC Successful Response.
+ * @see <a href="https://www.jsonrpc.org/specification">JSON-RPC</a>
+ *
+ * @param jsonrpc Version of the JSON-RPC protocol.
+ * @param error Error representation
+ * @param id This member is REQUIRED. It MUST be the same as the value of the id member in the Request Object. If there was an error in detecting the id in the Request object, it MUST be Null.
+ * @param <I> The type of the id field (String, Number, or null).
+ * @param <T> The type of additional error information
+ */
+@JsonInclude(JsonInclude.Include.ALWAYS)
+@Serdeable
+public record ErrorResponse<I, T>(
+    @NonNull String jsonrpc,
+    @NonNull Error<T> error,
+    @Nullable I id) {
+
+    public ErrorResponse(Error<T> error, I id) {
+        this(Request.VERSION_2_0, error, id);
+    }
+
+    public ErrorResponse(Error<T> error) {
+        this(Request.VERSION_2_0, error, null);
+    }
+}

--- a/micronaut-json-rpc/src/main/java/io/micronaut/mcp/jsonrpc/Request.java
+++ b/micronaut-json-rpc/src/main/java/io/micronaut/mcp/jsonrpc/Request.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.mcp.jsonrpc;
+
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.serde.annotation.Serdeable;
+
+/**
+ * JSON-RPC Request.
+ * @see <a href="https://www.jsonrpc.org/specification">JSON-RPC</a>
+ *
+ * @param jsonrpc Version of the JSON-RPC protocol.
+ * @param method  A String containing the name of the method to be invoked.
+ * @param params  A Structured value that holds the parameter values to be used during the invocation of the method.
+ * @param id      An identifier established by the Client that MUST contain a String, Number, or NULL value if included. If it is not included it is assumed to be a notification. The value SHOULD normally not be Null and Numbers SHOULD NOT contain fractional parts.
+ * @param <P>     The type of the params field.
+ * @param <I>     The type of the id field (String, Number, or null).
+ */
+@Serdeable
+public record Request<P, I>(
+    String jsonrpc,
+    String method,
+    @Nullable P params,
+    @Nullable I id
+) {
+    public static final String VERSION_2_0 = "2.0";
+
+    public Request(String method, P params, I id) {
+        this(VERSION_2_0, method, params, id);
+    }
+}

--- a/micronaut-json-rpc/src/main/java/io/micronaut/mcp/jsonrpc/SuccessfulResponse.java
+++ b/micronaut-json-rpc/src/main/java/io/micronaut/mcp/jsonrpc/SuccessfulResponse.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.mcp.jsonrpc;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.serde.annotation.Serdeable;
+
+/**
+ * JSON-RPC Successful Response.
+ * @see <a href="https://www.jsonrpc.org/specification">JSON-RPC</a>
+ *
+ * @param jsonrpc Version of the JSON-RPC protocol.
+ * @param result  The value is determined by the method invoked on the Server.
+ * @param id      This member is REQUIRED. It MUST be the same as the value of the id member in the Request Object. If there was an error in detecting the id in the Request object, it MUST be Null.
+ * @param <R>     The type of the result field.
+ * @param <I>     The type of the id field (String, Number, or null).
+ */
+@Serdeable
+public record SuccessfulResponse<R, I>(
+    @NonNull String jsonrpc,
+    @NonNull R result,
+    @Nullable I id) {
+    public SuccessfulResponse(R result, I id) {
+        this(Request.VERSION_2_0, result, id);
+    }
+}

--- a/micronaut-json-rpc/src/main/java/io/micronaut/mcp/jsonrpc/package-info.java
+++ b/micronaut-json-rpc/src/main/java/io/micronaut/mcp/jsonrpc/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Classes related to the JSON-RPC 2.0 specification.
+ * @see <a href="https://www.jsonrpc.org/specification">JSON RPC</a>
+ */
+package io.micronaut.mcp.jsonrpc;

--- a/micronaut-json-rpc/src/test/java/io/micronaut/mcp/jsonrpc/ErrorCodeTest.java
+++ b/micronaut-json-rpc/src/test/java/io/micronaut/mcp/jsonrpc/ErrorCodeTest.java
@@ -1,0 +1,58 @@
+package io.micronaut.mcp.jsonrpc;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class ErrorCodeTest{
+    @Test
+    void testOfKnownValues() {
+        assertAll(
+            () -> {
+                ErrorCode code = ErrorCode.PARSE_ERROR;
+                assertEquals(code, ErrorCode.of(-32700));
+                assertEquals("Parse error", code.getMessage());
+                assertEquals("Invalid JSON was received by the server. An error occurred on the server while parsing the JSON text.", code.getMeaning());
+            },
+            () -> {
+                int codeNumber = -32600;
+                ErrorCode code = ErrorCode.INVALID_REQUEST;
+                assertEquals(code, ErrorCode.of(codeNumber));
+                assertEquals("Invalid Request", code.getMessage());
+                assertEquals("The JSON sent is not a valid Request object.", code.getMeaning());
+                assertEquals(codeNumber, code.getCode());
+            },
+            () -> {
+                ErrorCode code = ErrorCode.METHOD_NOT_FOUND;
+                assertEquals(code, ErrorCode.of(-32601));
+                assertEquals("Method not found", code.getMessage());
+                assertEquals("The method does not exist / is not available.", code.getMeaning());
+            },
+            () -> {
+                ErrorCode code = ErrorCode.INVALID_PARAMS;
+                assertEquals(code, ErrorCode.of(-32602));
+                assertEquals("Invalid params", code.getMessage());
+                assertEquals("Invalid method parameter(s).", code.getMeaning());
+            },
+            () -> {
+                ErrorCode code = ErrorCode.INTERNAL_ERROR;
+                assertEquals(code, ErrorCode.of(-32603));
+                assertEquals("Internal error", code.getMessage());
+                assertEquals("Internal JSON-RPC error.", code.getMeaning());
+            },
+            () -> {
+                ErrorCode code = ErrorCode.SERVER_ERROR;
+                assertEquals(code, ErrorCode.of(-32000));
+                assertEquals("Server error", code.getMessage());
+                assertEquals("Reserved for implementation-defined server-errors.", code.getMeaning());
+            }
+        );
+    }
+
+    @Test
+    void unknownErrorCode() {
+        assertNull(ErrorCode.of(8080));
+    }
+}

--- a/micronaut-json-rpc/src/test/java/io/micronaut/mcp/jsonrpc/ErrorResponseTest.java
+++ b/micronaut-json-rpc/src/test/java/io/micronaut/mcp/jsonrpc/ErrorResponseTest.java
@@ -1,0 +1,21 @@
+package io.micronaut.mcp.jsonrpc;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ErrorResponseTest {
+
+    @Test
+    void testErrorResponse() {
+        var response = new ErrorResponse<>(new Error<>(ErrorCode.METHOD_NOT_FOUND), "1");
+        assertEquals("1", response.id());
+        assertEquals(new Error<>(ErrorCode.METHOD_NOT_FOUND), response.error());
+        assertEquals("2.0", response.jsonrpc());
+
+        response = new ErrorResponse<>(new Error<>(ErrorCode.METHOD_NOT_FOUND));
+        assertNull(response.id());
+        assertEquals(new Error<>(ErrorCode.METHOD_NOT_FOUND), response.error());
+        assertEquals("2.0", response.jsonrpc());
+    }
+}

--- a/micronaut-json-rpc/src/test/java/io/micronaut/mcp/jsonrpc/ErrorTest.java
+++ b/micronaut-json-rpc/src/test/java/io/micronaut/mcp/jsonrpc/ErrorTest.java
@@ -1,0 +1,16 @@
+package io.micronaut.mcp.jsonrpc;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ErrorTest {
+
+    @Test
+    void errorWithCode() {
+        var error = new Error<>(ErrorCode.METHOD_NOT_FOUND);
+        assertEquals(-32601, error.code());
+        assertEquals("Method not found", error.message());
+        assertNull(error.data());
+    }
+}

--- a/micronaut-json-rpc/src/test/java/io/micronaut/mcp/jsonrpc/RequestTest.java
+++ b/micronaut-json-rpc/src/test/java/io/micronaut/mcp/jsonrpc/RequestTest.java
@@ -1,0 +1,23 @@
+package io.micronaut.mcp.jsonrpc;
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@MicronautTest(startApplication = false)
+class RequestTest {
+
+    @Test
+    void testRequest() {
+        List<Integer> params = List.of(42, 23);
+        Integer id = 1;
+        String method = "subtract";
+        var req = new Request<>(method, params, id);
+        assertEquals("2.0", req.jsonrpc());
+        assertEquals(method, req.method());
+        assertEquals(params, req.params());
+        assertEquals(id, req.id());
+    }
+}

--- a/micronaut-json-rpc/src/test/java/io/micronaut/mcp/jsonrpc/SuccessfulResponseTest.java
+++ b/micronaut-json-rpc/src/test/java/io/micronaut/mcp/jsonrpc/SuccessfulResponseTest.java
@@ -1,0 +1,17 @@
+package io.micronaut.mcp.jsonrpc;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+class SuccessfulResponseTest {
+
+    @Test
+    void successfulResponse() {
+        var response = new SuccessfulResponse<>(19, 1);
+        assertEquals(1, response.id());
+        assertEquals(19, response.result());
+        assertEquals("2.0", response.jsonrpc());
+    }
+}

--- a/micronaut-json-rpc/src/test/resources/logback.xml
+++ b/micronaut-json-rpc/src/test/resources/logback.xml
@@ -1,0 +1,10 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,13 +9,19 @@ plugins {
     id 'io.micronaut.build.shared.settings' version '7.5.0'
 }
 
-rootProject.name = 'project-template-parent'
+rootProject.name = 'micronaut-mcp-parent'
 
+include 'micronaut-json-rpc'
 include 'micronaut-mcp'
 include 'micronaut-mcp-bom'
+include 'test-suite-json-rpc-tck'
+include 'test-suite-json-rpc-tck-serde'
+include 'test-suite-json-rpc-tck-jackson'
 
 enableFeaturePreview 'TYPESAFE_PROJECT_ACCESSORS'
 
 micronautBuild {
+    useStandardizedProjectNames.set(true)
     importMicronautCatalog()
+    importMicronautCatalog("micronaut-serde")
 }

--- a/test-suite-json-rpc-tck-jackson/build.gradle.kts
+++ b/test-suite-json-rpc-tck-jackson/build.gradle.kts
@@ -1,0 +1,6 @@
+plugins {
+    id("io.micronaut.build.internal.mcp-tck-suite")
+}
+dependencies {
+    testImplementation(mn.micronaut.jackson.databind)
+}

--- a/test-suite-json-rpc-tck-jackson/src/test/java/io/micronaut/mcp/jsonrpc/tck/serde/SerdeJsonRpcSerializationSuite.java
+++ b/test-suite-json-rpc-tck-jackson/src/test/java/io/micronaut/mcp/jsonrpc/tck/serde/SerdeJsonRpcSerializationSuite.java
@@ -1,0 +1,12 @@
+package io.micronaut.mcp.jsonrpc.tck.serde;
+
+import org.junit.platform.suite.api.ExcludeClassNamePatterns;
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SelectPackages;
+import org.junit.platform.suite.api.SuiteDisplayName;
+
+@Suite
+@SelectPackages("io.micronaut.mcp.jsonrpc.tck")
+@SuiteDisplayName("JSON RPC Serialization TCK Jackson")
+public class SerdeJsonRpcSerializationSuite {
+}

--- a/test-suite-json-rpc-tck-jackson/src/test/resources/logback.xml
+++ b/test-suite-json-rpc-tck-jackson/src/test/resources/logback.xml
@@ -1,0 +1,10 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/test-suite-json-rpc-tck-serde/build.gradle.kts
+++ b/test-suite-json-rpc-tck-serde/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+    id("io.micronaut.build.internal.mcp-tck-suite")
+}
+dependencies {
+    testAnnotationProcessor(mnSerde.micronaut.serde.processor)
+    testImplementation(mnSerde.micronaut.serde.jackson)
+}
+

--- a/test-suite-json-rpc-tck-serde/src/test/java/io/micronaut/mcp/jsonrpc/tck/jackson/JacksonJsonRpcSerializationSuite.java
+++ b/test-suite-json-rpc-tck-serde/src/test/java/io/micronaut/mcp/jsonrpc/tck/jackson/JacksonJsonRpcSerializationSuite.java
@@ -1,0 +1,15 @@
+package io.micronaut.mcp.jsonrpc.tck.jackson;
+
+import org.junit.platform.suite.api.ExcludeClassNamePatterns;
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SelectPackages;
+import org.junit.platform.suite.api.SuiteDisplayName;
+
+@Suite
+@SelectPackages("io.micronaut.mcp.jsonrpc.tck")
+@SuiteDisplayName("JSON RPC Serialization TCK Serde")
+@ExcludeClassNamePatterns({
+    "io.micronaut.mcp.jsonrpc.tck.ErrorResponseIdNullTest"
+})
+public class JacksonJsonRpcSerializationSuite {
+}

--- a/test-suite-json-rpc-tck-serde/src/test/resources/logback.xml
+++ b/test-suite-json-rpc-tck-serde/src/test/resources/logback.xml
@@ -1,0 +1,10 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/test-suite-json-rpc-tck/build.gradle.kts
+++ b/test-suite-json-rpc-tck/build.gradle.kts
@@ -1,0 +1,10 @@
+plugins {
+    id("groovy")
+    id("java-library")
+}
+dependencies {
+    annotationProcessor(mn.micronaut.inject.java)
+    implementation(mn.micronaut.json.core)
+    implementation(mnTest.micronaut.test.junit5)
+    implementation(projects.micronautJsonRpc)
+}

--- a/test-suite-json-rpc-tck/src/main/java/io/micronaut/mcp/jsonrpc/tck/ErrorResponseIdNullTest.java
+++ b/test-suite-json-rpc-tck/src/main/java/io/micronaut/mcp/jsonrpc/tck/ErrorResponseIdNullTest.java
@@ -1,0 +1,24 @@
+package io.micronaut.mcp.jsonrpc.tck;
+
+import io.micronaut.json.JsonMapper;
+import io.micronaut.mcp.jsonrpc.Error;
+import io.micronaut.mcp.jsonrpc.ErrorCode;
+import io.micronaut.mcp.jsonrpc.ErrorResponse;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@MicronautTest(startApplication = false)
+class ErrorResponseIdNullTest {
+    @Test
+    void errorResponseSerialization(JsonMapper jsonMapper) throws IOException {
+        String expected = """
+            {"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error"},"id":null}""";
+        var response = new ErrorResponse<>(new Error<>(ErrorCode.PARSE_ERROR));
+        var json = jsonMapper.writeValueAsString(response);
+        assertEquals(expected, json);
+    }
+}

--- a/test-suite-json-rpc-tck/src/main/java/io/micronaut/mcp/jsonrpc/tck/ErrorResponseSerializationTest.java
+++ b/test-suite-json-rpc-tck/src/main/java/io/micronaut/mcp/jsonrpc/tck/ErrorResponseSerializationTest.java
@@ -12,7 +12,7 @@ import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @MicronautTest(startApplication = false)
-class ErrorResponseTest {
+class ErrorResponseSerializationTest {
 
     @Test
     void errorResponseSerialization(JsonMapper jsonMapper) throws IOException {

--- a/test-suite-json-rpc-tck/src/main/java/io/micronaut/mcp/jsonrpc/tck/ErrorResponseTest.java
+++ b/test-suite-json-rpc-tck/src/main/java/io/micronaut/mcp/jsonrpc/tck/ErrorResponseTest.java
@@ -1,0 +1,25 @@
+package io.micronaut.mcp.jsonrpc.tck;
+
+import io.micronaut.json.JsonMapper;
+import io.micronaut.mcp.jsonrpc.Error;
+import io.micronaut.mcp.jsonrpc.ErrorCode;
+import io.micronaut.mcp.jsonrpc.ErrorResponse;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@MicronautTest(startApplication = false)
+class ErrorResponseTest {
+
+    @Test
+    void errorResponseSerialization(JsonMapper jsonMapper) throws IOException {
+        String expected = """
+            {"jsonrpc":"2.0","error":{"code":-32601,"message":"Method not found"},"id":"1"}""";
+        var response = new ErrorResponse<>(new Error<>(ErrorCode.METHOD_NOT_FOUND), "1");
+        String json = jsonMapper.writeValueAsString(response);
+        assertEquals(expected, json);
+    }
+}

--- a/test-suite-json-rpc-tck/src/main/java/io/micronaut/mcp/jsonrpc/tck/RequestTest.java
+++ b/test-suite-json-rpc-tck/src/main/java/io/micronaut/mcp/jsonrpc/tck/RequestTest.java
@@ -1,0 +1,26 @@
+package io.micronaut.mcp.jsonrpc.tck;
+
+import io.micronaut.json.JsonMapper;
+import io.micronaut.mcp.jsonrpc.Request;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@MicronautTest(startApplication = false)
+public class RequestTest {
+    @Test
+    void requestSerialization(JsonMapper jsonMapper) throws IOException {
+        List<Integer> params = List.of(42, 23);
+        Integer id = 1;
+        String method = "subtract";
+        var req = new Request<>(method, params, id);
+        var json = jsonMapper.writeValueAsString(req);
+        assertEquals("""
+            {"jsonrpc":"2.0","method":"subtract","params":[42,23],"id":1}""", json);
+
+    }
+}

--- a/test-suite-json-rpc-tck/src/main/java/io/micronaut/mcp/jsonrpc/tck/SuccessfulResponseSerializationTest.java
+++ b/test-suite-json-rpc-tck/src/main/java/io/micronaut/mcp/jsonrpc/tck/SuccessfulResponseSerializationTest.java
@@ -10,7 +10,7 @@ import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @MicronautTest(startApplication = false)
-class SuccessfulResponseTest {
+class SuccessfulResponseSerializationTest {
 
     @Test
     void successfulResponseSerialization(JsonMapper jsonMapper) throws IOException {

--- a/test-suite-json-rpc-tck/src/main/java/io/micronaut/mcp/jsonrpc/tck/SuccessfulResponseTest.java
+++ b/test-suite-json-rpc-tck/src/main/java/io/micronaut/mcp/jsonrpc/tck/SuccessfulResponseTest.java
@@ -1,0 +1,23 @@
+package io.micronaut.mcp.jsonrpc.tck;
+
+import io.micronaut.json.JsonMapper;
+import io.micronaut.mcp.jsonrpc.SuccessfulResponse;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@MicronautTest(startApplication = false)
+class SuccessfulResponseTest {
+
+    @Test
+    void successfulResponseSerialization(JsonMapper jsonMapper) throws IOException {
+        String expected = """
+            {"jsonrpc":"2.0","result":19,"id":1}""";
+        var response = new SuccessfulResponse<>(19, 1);
+        String json = jsonMapper.writeValueAsString(response);
+        assertEquals(expected, json);
+    }
+}


### PR DESCRIPTION
MCP uses JSON-RPC spec.

https://modelcontextprotocol.io/specification/2025-06-18/basic 

> All messages between MCP clients and servers MUST follow the JSON-RPC 2.0 specification.

This pull-request adds serdeable records according to the JSON-RPC specification.