### PR TITLE
API McpRequestHandler

### DIFF
--- a/micronaut-json-rpc/src/main/java/io/micronaut/mcp/jsonrpc/ErrorResponse.java
+++ b/micronaut-json-rpc/src/main/java/io/micronaut/mcp/jsonrpc/ErrorResponse.java
@@ -44,4 +44,8 @@ public record ErrorResponse<I, T>(
     public ErrorResponse(Error<T> error) {
         this(Request.VERSION_2_0, error, null);
     }
+
+    public ErrorResponse(ErrorCode errorCode) {
+        this(Request.VERSION_2_0, new Error<>(errorCode), null);
+    }
 }

--- a/micronaut-json-rpc/src/main/java/io/micronaut/mcp/jsonrpc/Request.java
+++ b/micronaut-json-rpc/src/main/java/io/micronaut/mcp/jsonrpc/Request.java
@@ -44,6 +44,7 @@ public record Request<P, I>(
     public Request(String method, I id) {
         this(VERSION_2_0, method, null, id);
     }
+
     public Request(String method, P params, I id) {
         this(VERSION_2_0, method, params, id);
     }

--- a/micronaut-json-rpc/src/test/java/io/micronaut/mcp/jsonrpc/ErrorResponseTest.java
+++ b/micronaut-json-rpc/src/test/java/io/micronaut/mcp/jsonrpc/ErrorResponseTest.java
@@ -17,5 +17,10 @@ class ErrorResponseTest {
         assertNull(response.id());
         assertEquals(new Error<>(ErrorCode.METHOD_NOT_FOUND), response.error());
         assertEquals("2.0", response.jsonrpc());
+
+        response = new ErrorResponse<>(ErrorCode.METHOD_NOT_FOUND);
+        assertNull(response.id());
+        assertEquals(new Error<>(ErrorCode.METHOD_NOT_FOUND), response.error());
+        assertEquals("2.0", response.jsonrpc());
     }
 }

--- a/micronaut-mcp-http-server/build.gradle.kts
+++ b/micronaut-mcp-http-server/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 dependencies {
     api(mn.micronaut.http)
-    api(projects.micronautJsonRpc)
+    api(projects.micronautMcp)
     annotationProcessor(mnValidation.micronaut.validation.processor)
     api(mnValidation.micronaut.validation)
     testAnnotationProcessor(mn.micronaut.inject.java)

--- a/micronaut-mcp-http-server/src/main/java/io/micronaut/mcp/http/server/McpController.java
+++ b/micronaut-mcp-http-server/src/main/java/io/micronaut/mcp/http/server/McpController.java
@@ -39,7 +39,6 @@ import jakarta.validation.Valid;
 @Controller("${" + McpControllerConfiguration.PROPERTY_PATH + ":" + McpControllerConfiguration.DEFAULT_PATH + "}")
 @Internal
 class McpController {
-    private static final String MCP_METHOD_PING = "ping";
     private final McpRequestHandler mcpRequestHandler;
 
     McpController(McpRequestHandler mcpRequestHandler) {

--- a/micronaut-mcp-http-server/src/main/java/io/micronaut/mcp/http/server/McpController.java
+++ b/micronaut-mcp-http-server/src/main/java/io/micronaut/mcp/http/server/McpController.java
@@ -27,22 +27,35 @@ import io.micronaut.http.annotation.Get;
 import io.micronaut.http.annotation.Post;
 import io.micronaut.http.annotation.RequestBean;
 import io.micronaut.http.annotation.Status;
+import io.micronaut.mcp.ErrorMcpResponse;
+import io.micronaut.mcp.McpRequest;
+import io.micronaut.mcp.McpRequestHandler;
+import io.micronaut.mcp.McpResponse;
+import io.micronaut.mcp.SuccessfulMcpResponse;
 import io.micronaut.mcp.jsonrpc.Request;
-import io.micronaut.mcp.jsonrpc.SuccessfulResponse;
 import jakarta.validation.Valid;
-import java.util.Collections;
 
 @Requires(property = McpControllerConfiguration.PROPERTY_ENABLED, notEquals = StringUtils.FALSE, defaultValue = StringUtils.TRUE)
 @Controller("${" + McpControllerConfiguration.PROPERTY_PATH + ":" + McpControllerConfiguration.DEFAULT_PATH + "}")
 @Internal
 class McpController {
     private static final String MCP_METHOD_PING = "ping";
+    private final McpRequestHandler mcpRequestHandler;
+
+    McpController(McpRequestHandler mcpRequestHandler) {
+        this.mcpRequestHandler = mcpRequestHandler;
+    }
 
     @Post
     HttpResponse<?> mcpPost(@NonNull @RequestBean McpHttpRequest mcpHttpRequest,
                             @NonNull @Body @Valid Request<?, ?> jsonRpcRequest) {
-        if (jsonRpcRequest.method().equals(MCP_METHOD_PING)) { // //will implement a dispatcher API in future PRs
-            return HttpResponse.ok(new SuccessfulResponse<>(Collections.emptyMap(), jsonRpcRequest.id()));
+        McpRequest mcpRequest = new McpRequest(mcpHttpRequest.protocolVersion(), mcpHttpRequest.sessionId(), mcpHttpRequest.lastEventId(), jsonRpcRequest);
+        McpResponse mcpResponse = mcpRequestHandler.handle(mcpRequest);
+        if (mcpResponse instanceof SuccessfulMcpResponse rsp) {
+            return HttpResponse.ok(rsp.response());
+        }
+        if (mcpResponse instanceof ErrorMcpResponse rsp) {
+            return HttpResponse.unprocessableEntity().body(rsp.response());
         }
         return HttpResponse.unprocessableEntity();
     }

--- a/micronaut-mcp/build.gradle.kts
+++ b/micronaut-mcp/build.gradle.kts
@@ -1,3 +1,15 @@
+import io.micronaut.build.TestFramework
+
 plugins {
     id("io.micronaut.build.internal.mcp-module")
+}
+dependencies {
+    api(projects.micronautJsonRpc)
+    testRuntimeOnly(mnLogging.logback.classic)
+}
+micronautBuild {
+    testFramework = TestFramework.JUNIT5
+}
+tasks.withType<Test> {
+    useJUnitPlatform()
 }

--- a/micronaut-mcp/src/main/java/io/micronaut/mcp/CompositeMcpRequestHandler.java
+++ b/micronaut-mcp/src/main/java/io/micronaut/mcp/CompositeMcpRequestHandler.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.mcp;
+
+import io.micronaut.context.annotation.Primary;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.mcp.jsonrpc.ErrorCode;
+import io.micronaut.mcp.jsonrpc.ErrorResponse;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import java.util.Map;
+
+/**
+ * A composite {@link McpRequestHandler} that delegates to other handlers based on the method name.
+ * If no handler is found for a method, it returns an error response.
+ */
+@Internal
+@Named(CompositeMcpRequestHandler.NAME)
+@Primary
+@Singleton
+class CompositeMcpRequestHandler implements McpRequestHandler {
+    public static final String NAME = "composite";
+    private final Map<String, McpRequestHandler> handlers;
+
+    public CompositeMcpRequestHandler(Map<String, McpRequestHandler> handlers) {
+        this.handlers = handlers;
+    }
+
+    @Override
+    @NonNull
+    public McpResponse handle(@NonNull McpRequest request) {
+        McpRequestHandler handler = handlers.get(request.message().method());
+        if (handler != null) {
+            return handler.handle(request);
+        }
+        return new ErrorMcpResponse(new ErrorResponse<>(ErrorCode.METHOD_NOT_FOUND));
+    }
+
+    @Override
+    public @NonNull String getName() {
+        return NAME;
+    }
+}

--- a/micronaut-mcp/src/main/java/io/micronaut/mcp/ErrorMcpResponse.java
+++ b/micronaut-mcp/src/main/java/io/micronaut/mcp/ErrorMcpResponse.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.mcp;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.mcp.jsonrpc.ErrorResponse;
+
+/**
+ * MCP Error Response.
+ * @param response the JSON-RPC response message
+ */
+@Introspected
+public record ErrorMcpResponse(ErrorResponse<?, ?> response) implements McpResponse {
+}

--- a/micronaut-mcp/src/main/java/io/micronaut/mcp/McpRequest.java
+++ b/micronaut-mcp/src/main/java/io/micronaut/mcp/McpRequest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.mcp;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.mcp.jsonrpc.Request;
+
+/**
+ * MCP Request.
+ * @param protocolVersion MCP protocol version
+ * @param sessionId Session ID
+ * @param lastEventId Last event ID
+ * @param message JSON-RPC message
+ */
+@Introspected
+public record McpRequest(@NonNull String protocolVersion,
+                         @Nullable String sessionId,
+                         @Nullable String lastEventId,
+                         Request<?, ?> message) {
+}

--- a/micronaut-mcp/src/main/java/io/micronaut/mcp/McpRequestHandler.java
+++ b/micronaut-mcp/src/main/java/io/micronaut/mcp/McpRequestHandler.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.mcp;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.naming.Named;
+import io.micronaut.core.order.Ordered;
+
+/**
+ * API for handling MCP requests.
+ */
+public interface McpRequestHandler extends Ordered, Named {
+    /**
+     * Handle a given MCP request.
+     * @param request the MCP request
+     * @return the MCP response
+     */
+    @NonNull McpResponse handle(@NonNull McpRequest request);
+}

--- a/micronaut-mcp/src/main/java/io/micronaut/mcp/McpResponse.java
+++ b/micronaut-mcp/src/main/java/io/micronaut/mcp/McpResponse.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.mcp;
+
+/**
+ * Marker interface for MCP Responses.
+ * For successful responses, use {@link SuccessfulMcpResponse}.
+ * For error responses, use {@link ErrorMcpResponse}.
+ */
+public interface McpResponse {
+}

--- a/micronaut-mcp/src/main/java/io/micronaut/mcp/PingMcpRequestHandler.java
+++ b/micronaut-mcp/src/main/java/io/micronaut/mcp/PingMcpRequestHandler.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.mcp;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.mcp.jsonrpc.SuccessfulResponse;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+import java.util.Collections;
+
+/**
+ * A {@link McpRequestHandler} for method "ping".
+ */
+@Named(PingMcpRequestHandler.NAME)
+@Singleton
+public class PingMcpRequestHandler implements McpRequestHandler {
+    public static final String NAME = "ping";
+
+    @Override
+    public McpResponse handle(McpRequest request) {
+        return new SuccessfulMcpResponse(new SuccessfulResponse<>(Collections.emptyMap(), request.message().id()));
+    }
+
+    @Override
+    public @NonNull String getName() {
+        return NAME;
+    }
+}

--- a/micronaut-mcp/src/main/java/io/micronaut/mcp/SuccessfulMcpResponse.java
+++ b/micronaut-mcp/src/main/java/io/micronaut/mcp/SuccessfulMcpResponse.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.mcp;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.mcp.jsonrpc.SuccessfulResponse;
+
+/**
+ * Successful MCP Response.
+ * @param response the JSON-RPC response message
+ */
+@Introspected
+public record SuccessfulMcpResponse(SuccessfulResponse<?, ?> response) implements McpResponse {
+}

--- a/micronaut-mcp/src/test/java/io/micronaut/mcp/CompositeMcpRequestHandlerTest.java
+++ b/micronaut-mcp/src/test/java/io/micronaut/mcp/CompositeMcpRequestHandlerTest.java
@@ -1,0 +1,16 @@
+package io.micronaut.mcp;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CompositeMcpRequestHandlerTest {
+
+    @Test
+    void nameIsPing() {
+        CompositeMcpRequestHandler handler = new CompositeMcpRequestHandler(Collections.emptyMap());
+        assertEquals("composite", handler.getName());
+    }
+}

--- a/micronaut-mcp/src/test/java/io/micronaut/mcp/ErrorMcpResponseTest.java
+++ b/micronaut-mcp/src/test/java/io/micronaut/mcp/ErrorMcpResponseTest.java
@@ -1,0 +1,13 @@
+package io.micronaut.mcp;
+
+import io.micronaut.core.beans.BeanIntrospection;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class ErrorMcpResponseTest {
+    @Test
+    void isAnnotatedWithIntrospected() {
+        assertDoesNotThrow(() -> BeanIntrospection.getIntrospection(ErrorMcpResponse.class));
+    }
+}

--- a/micronaut-mcp/src/test/java/io/micronaut/mcp/McpRequestTest.java
+++ b/micronaut-mcp/src/test/java/io/micronaut/mcp/McpRequestTest.java
@@ -1,0 +1,13 @@
+package io.micronaut.mcp;
+
+import io.micronaut.core.beans.BeanIntrospection;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class McpRequestTest {
+    @Test
+    void isAnnotatedWithIntrospected() {
+        assertDoesNotThrow(() -> BeanIntrospection.getIntrospection(McpRequest.class));
+    }
+}

--- a/micronaut-mcp/src/test/java/io/micronaut/mcp/PingMcpRequestHandlerTest.java
+++ b/micronaut-mcp/src/test/java/io/micronaut/mcp/PingMcpRequestHandlerTest.java
@@ -1,0 +1,14 @@
+package io.micronaut.mcp;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PingMcpRequestHandlerTest {
+
+    @Test
+    void nameIsPing() {
+        PingMcpRequestHandler handler = new PingMcpRequestHandler();
+        assertEquals("ping", handler.getName());
+    }
+}

--- a/micronaut-mcp/src/test/java/io/micronaut/mcp/SuccessfulMcpResponseTest.java
+++ b/micronaut-mcp/src/test/java/io/micronaut/mcp/SuccessfulMcpResponseTest.java
@@ -1,0 +1,13 @@
+package io.micronaut.mcp;
+
+import io.micronaut.core.beans.BeanIntrospection;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SuccessfulMcpResponseTest {
+    @Test
+    void isAnnotatedWithIntrospected() {
+        assertDoesNotThrow(() -> BeanIntrospection.getIntrospection(SuccessfulMcpResponse.class));
+    }
+}

--- a/micronaut-mcp/src/test/resources/logback.xml
+++ b/micronaut-mcp/src/test/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+    <logger name="io.micronaut.http.client" level="TRACE"/>
+</configuration>


### PR DESCRIPTION
This pull-request adds a simple `McpRequestHandler` API to handle MCP request is a composite way. 

This pull-request moves the logic to the `micronaut-mcp` module which does not depend on HTTP to support other transports. 