### PR TITLE
fix: handle primitive list requests graciously

### DIFF
--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -9,4 +9,8 @@
               <!-- files="DefaultBeanContext.java|BeanDefinitionWriter.java|DefaultHttpClient.java"/> -->
 
     <suppress checks="MissingJavadocType" files=".*doc-examples.*" />
+    <!-- Disable all Checkstyle checks for the StdioServerTransportProviderReplacement class -->
+    <suppress
+        checks=".*"
+        files=".*[/\\]io[/\\]micronaut[/\\]mcp[/\\]server[/\\]stdio[/\\]StdioServerTransportProviderReplacement\.java"/>
 </suppressions>

--- a/micronaut-mcp-server-java-sdk/src/main/java/io/micronaut/mcp/server/exceptions/JsonRrpcResponseUtils.java
+++ b/micronaut-mcp-server-java-sdk/src/main/java/io/micronaut/mcp/server/exceptions/JsonRrpcResponseUtils.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.mcp.server.exceptions;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.modelcontextprotocol.spec.McpError;
+import io.modelcontextprotocol.spec.McpSchema;
+
+import java.util.Collections;
+
+import static io.modelcontextprotocol.spec.McpSchema.JSONRPC_VERSION;
+
+/**
+ * Utility class to generate {@link McpSchema.JSONRPCResponse}s allowing the gracious handling of MCP errors for primitive listings.
+ */
+@Internal
+public final class JsonRrpcResponseUtils {
+    private static final String HANDLER_FOR_REQUEST_TYPE_PROMPTS_LIST = "Missing handler for request type: prompts/list";
+    private static final String HANDLER_FOR_REQUEST_TYPE_RESOURCES_LIST = "Missing handler for request type: resources/list";
+    private static final String HANDLER_FOR_REQUEST_TYPE_TOOLS_LIST = "Missing handler for request type: tools/list";
+    private static final String METHOD_NOT_FOUND_PROMPTS_LIST = "Method not found: prompts/list";
+    private static final String METHOD_NOT_FOUND_RESOURCES_LIST = "Method not found: resources/list";
+    private static final String METHOD_NOT_FOUND_TOOLS_LIST = "Method not found: tools/list";
+
+    private JsonRrpcResponseUtils() {
+    }
+
+    /**
+     * If the MCP error is related to a listing request to a primitive, it returns an empty response for that primitive instead of an error.
+     * @param e MCP Error
+     * @param jsonrpcMessage JSON RPC Message
+     * @return a JSON RPC Response
+     */
+    @NonNull
+    public static McpSchema.JSONRPCResponse jsonrpcResponse(@NonNull McpError e, @NonNull McpSchema.JSONRPCMessage jsonrpcMessage) {
+        if (e.getMessage() == null) {
+            return errorJsonrpcResponse(jsonrpcMessage, e);
+        }
+        switch (e.getMessage()) {
+            case HANDLER_FOR_REQUEST_TYPE_PROMPTS_LIST -> {
+                Object id = jsonrpcMessage instanceof McpSchema.JSONRPCRequest jsonrpcRequest ? jsonrpcRequest.id() : null;
+                return new McpSchema.JSONRPCResponse(JSONRPC_VERSION,
+                    id,
+                    new McpSchema.ListPromptsResult(Collections.emptyList(), null), null);
+            }
+            case HANDLER_FOR_REQUEST_TYPE_RESOURCES_LIST -> {
+                Object id = jsonrpcMessage instanceof McpSchema.JSONRPCRequest jsonrpcRequest ? jsonrpcRequest.id() : null;
+                return new McpSchema.JSONRPCResponse(JSONRPC_VERSION,
+                    id,
+                    new McpSchema.ListResourcesResult(Collections.emptyList(), null), null);
+            }
+            case HANDLER_FOR_REQUEST_TYPE_TOOLS_LIST -> {
+                Object id = jsonrpcMessage instanceof McpSchema.JSONRPCRequest jsonrpcRequest ? jsonrpcRequest.id() : null;
+                return new McpSchema.JSONRPCResponse(JSONRPC_VERSION,
+                    id,
+                    new McpSchema.ListToolsResult(Collections.emptyList(), null), null);
+            }
+            default -> errorJsonrpcResponse(jsonrpcMessage, e);
+        }
+        return errorJsonrpcResponse(jsonrpcMessage, e);
+    }
+
+
+    /**
+     * If the JSONRPCResponse signals an error and the error is related to a listing request to a primitive, it returns an empty response for that primitive instead of an error.
+     * @param jsonrpcResponse JSON RPC Response
+     * @return a JSON RPC Response
+     */
+    @Nullable
+    public static McpSchema.JSONRPCMessage map(@Nullable McpSchema.JSONRPCResponse jsonrpcResponse) {
+        if (jsonrpcResponse == null) {
+            return null;
+        }
+        if (jsonrpcResponse.error() == null) {
+            return jsonrpcResponse;
+        }
+        McpSchema.JSONRPCResponse.JSONRPCError jsonrpcError = jsonrpcResponse.error();
+        String message = jsonrpcError.message();
+        if (message == null) {
+            return jsonrpcResponse;
+        }
+        return switch (message) {
+            case METHOD_NOT_FOUND_PROMPTS_LIST -> new McpSchema.JSONRPCResponse(JSONRPC_VERSION,
+                jsonrpcResponse.id(),
+                new McpSchema.ListPromptsResult(Collections.emptyList(), null), null);
+            case METHOD_NOT_FOUND_RESOURCES_LIST -> new McpSchema.JSONRPCResponse(JSONRPC_VERSION,
+                jsonrpcResponse.id(),
+                new McpSchema.ListResourcesResult(Collections.emptyList(), null), null);
+            case METHOD_NOT_FOUND_TOOLS_LIST -> new McpSchema.JSONRPCResponse(JSONRPC_VERSION,
+                jsonrpcResponse.id(),
+                new McpSchema.ListToolsResult(Collections.emptyList(), null), null);
+            default -> jsonrpcResponse;
+        };
+    }
+
+    @NonNull
+    static McpSchema.JSONRPCResponse errorJsonrpcResponse(@NonNull McpSchema.JSONRPCMessage jsonrpcMessage,
+                                                          @NonNull McpError error) {
+        McpSchema.JSONRPCResponse.JSONRPCError jsonrpcError = error.getJsonRpcError();
+        if (jsonrpcError == null) {
+            jsonrpcError = new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.INTERNAL_ERROR,
+                error.getMessage(),
+                null);
+        }
+        return new McpSchema.JSONRPCResponse(
+            JSONRPC_VERSION,
+            jsonrpcMessage instanceof McpSchema.JSONRPCRequest jsonrpcRequest ? jsonrpcRequest.id() : null,
+            null,
+            jsonrpcError
+        );
+    }
+}

--- a/micronaut-mcp-server-java-sdk/src/main/java/io/micronaut/mcp/server/stateless/McpController.java
+++ b/micronaut-mcp-server-java-sdk/src/main/java/io/micronaut/mcp/server/stateless/McpController.java
@@ -27,6 +27,7 @@ import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
 import io.micronaut.http.annotation.Produces;
 import io.micronaut.mcp.conf.server.McpServerConfiguration;
+import io.micronaut.mcp.server.exceptions.JsonRrpcResponseUtils;
 import io.modelcontextprotocol.server.McpStatelessServerHandler;
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.server.McpTransportContextExtractor;
@@ -35,10 +36,9 @@ import io.modelcontextprotocol.spec.McpSchema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
+
 import java.util.Map;
 import java.util.function.Function;
-
-import static io.modelcontextprotocol.spec.McpSchema.JSONRPC_VERSION;
 
 /**
  * This class exposes a POST endpoint in route {@value McpServerConfiguration#DEFAULT_ENDPOINT}.
@@ -97,7 +97,7 @@ final class McpController {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Failed to handle JSON RPC Message: {}", e.getMessage());
         }
-        McpSchema.JSONRPCResponse rsp = errorJsonrpcResponse(jsonrpcMessage, e);
+        McpSchema.JSONRPCResponse rsp = JsonRrpcResponseUtils.jsonrpcResponse(e, jsonrpcMessage);
         return Mono.just(HttpResponse.status(status(rsp)).body(rsp));
     }
 
@@ -121,23 +121,6 @@ final class McpController {
             return new McpSchema.JSONRPCNotification(body.get(KEY_JSONRPC).toString(), body.get(KEY_METHOD).toString(), body.get(KEY_PARAMS));
         }
         return null;
-    }
-
-    @NonNull
-    static McpSchema.JSONRPCResponse errorJsonrpcResponse(@NonNull McpSchema.JSONRPCMessage jsonrpcMessage,
-                                                          @NonNull McpError error) {
-        McpSchema.JSONRPCResponse.JSONRPCError jsonrpcError = error.getJsonRpcError();
-        if (jsonrpcError == null) {
-            jsonrpcError = new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.INTERNAL_ERROR,
-                error.getMessage(),
-                null);
-        }
-        return new McpSchema.JSONRPCResponse(
-            JSONRPC_VERSION,
-            jsonrpcMessage instanceof McpSchema.JSONRPCRequest jsonrpcRequest ? jsonrpcRequest.id() : null,
-            null,
-            jsonrpcError
-        );
     }
 
     @NonNull

--- a/micronaut-mcp-server-java-sdk/src/main/java/io/micronaut/mcp/server/stdio/StdioServerTransportProviderFactory.java
+++ b/micronaut-mcp-server-java-sdk/src/main/java/io/micronaut/mcp/server/stdio/StdioServerTransportProviderFactory.java
@@ -19,7 +19,6 @@ import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Prototype;
 import io.micronaut.core.annotation.Internal;
 import io.modelcontextprotocol.json.McpJsonMapper;
-import io.modelcontextprotocol.server.transport.StdioServerTransportProvider;
 import io.modelcontextprotocol.spec.McpServerTransportProvider;
 
 @Internal
@@ -27,6 +26,6 @@ import io.modelcontextprotocol.spec.McpServerTransportProvider;
 final class StdioServerTransportProviderFactory {
     @Prototype
     McpServerTransportProvider createStdioServerTransportProvider(McpJsonMapper mcpJsonMapper) {
-        return new StdioServerTransportProvider(mcpJsonMapper);
+        return new StdioServerTransportProviderReplacement(mcpJsonMapper);
     }
 }

--- a/micronaut-mcp-server-java-sdk/src/main/java/io/micronaut/mcp/server/stdio/StdioServerTransportProviderReplacement.java
+++ b/micronaut-mcp-server-java-sdk/src/main/java/io/micronaut/mcp/server/stdio/StdioServerTransportProviderReplacement.java
@@ -1,0 +1,340 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.mcp.server.stdio;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.mcp.server.exceptions.JsonRrpcResponseUtils;
+import io.modelcontextprotocol.json.TypeRef;
+import io.modelcontextprotocol.spec.McpError;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpSchema.JSONRPCMessage;
+import io.modelcontextprotocol.spec.McpServerSession;
+import io.modelcontextprotocol.spec.McpServerTransport;
+import io.modelcontextprotocol.spec.McpServerTransportProvider;
+import io.modelcontextprotocol.spec.ProtocolVersions;
+import io.modelcontextprotocol.util.Assert;
+import io.modelcontextprotocol.json.McpJsonMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+
+/**
+ * Replacement for the MCP Java SDK {@code StdioTransportProvider}.
+ *
+ * <p>The only behavioral change from the upstream implementation is in
+ * {@link #setSessionFactory(io.modelcontextprotocol.spec.McpServerSession.Factory)}:
+ * the created {@code StdioMcpSessionTransport} anonymously overrides
+ * {@link io.modelcontextprotocol.spec.McpServerTransport#sendMessage(io.modelcontextprotocol.spec.McpSchema.JSONRPCMessage)}
+ * to normalize outbound {@link io.modelcontextprotocol.spec.McpSchema.JSONRPCResponse} values via
+ * {@link io.micronaut.mcp.server.exceptions.JsonRrpcResponseUtils#map(io.modelcontextprotocol.spec.McpSchema.JSONRPCResponse)}
+ * before delegating. All other behavior mirrors the upstream provider.</p>
+ */
+@Internal
+public final class StdioServerTransportProviderReplacement implements McpServerTransportProvider {
+
+	private static final Logger logger = LoggerFactory.getLogger(StdioServerTransportProviderReplacement.class);
+
+	private final McpJsonMapper jsonMapper;
+
+	private final InputStream inputStream;
+
+	private final OutputStream outputStream;
+
+	private McpServerSession session;
+
+	private final AtomicBoolean isClosing = new AtomicBoolean(false);
+
+	private final Sinks.One<Void> inboundReady = Sinks.one();
+
+	/**
+     * Creates a new StdioServerTransportProvider with the specified ObjectMapper and
+     * System streams.
+     *
+     * @param jsonMapper The JsonMapper to use for JSON serialization/deserialization
+     */
+	public StdioServerTransportProviderReplacement(McpJsonMapper jsonMapper) {
+		this(jsonMapper, System.in, System.out);
+	}
+
+	/**
+     * Creates a new StdioServerTransportProvider with the specified ObjectMapper and
+     * streams.
+     *
+     * @param jsonMapper   The JsonMapper to use for JSON serialization/deserialization
+     * @param inputStream  The input stream to read from
+     * @param outputStream The output stream to write to
+     */
+	public StdioServerTransportProviderReplacement(McpJsonMapper jsonMapper, InputStream inputStream, OutputStream outputStream) {
+		Assert.notNull(jsonMapper, "The JsonMapper can not be null");
+		Assert.notNull(inputStream, "The InputStream can not be null");
+		Assert.notNull(outputStream, "The OutputStream can not be null");
+
+		this.jsonMapper = jsonMapper;
+		this.inputStream = inputStream;
+		this.outputStream = outputStream;
+	}
+
+	@Override
+	public List<String> protocolVersions() {
+		return List.of(ProtocolVersions.MCP_2024_11_05);
+	}
+
+	@Override
+	public void setSessionFactory(McpServerSession.Factory sessionFactory) {
+		// Create a single session for the stdio connection
+		var transport = new StdioMcpSessionTransport() {
+            @Override
+            public Mono<Void> sendMessage(JSONRPCMessage message) {
+                if (message instanceof McpSchema.JSONRPCResponse jsonrpcResponse) {
+                    return super.sendMessage(JsonRrpcResponseUtils.map(jsonrpcResponse));
+                } else {
+                    return super.sendMessage(message);
+                }
+            }
+        };
+		this.session = sessionFactory.create(transport);
+		transport.initProcessing();
+	}
+
+	@Override
+	public Mono<Void> notifyClients(String method, Object params) {
+		if (this.session == null) {
+			return Mono.error(new McpError("No session to close"));
+		}
+		return this.session.sendNotification(method, params)
+			.doOnError(e -> logger.error("Failed to send notification: {}", e.getMessage()));
+	}
+
+	@Override
+	public Mono<Void> closeGracefully() {
+		if (this.session == null) {
+			return Mono.empty();
+		}
+		return this.session.closeGracefully();
+	}
+
+	/**
+     * Implementation of McpServerTransport for the stdio session.
+     */
+	private class StdioMcpSessionTransport implements McpServerTransport {
+
+		private final Sinks.Many<JSONRPCMessage> inboundSink;
+
+		private final Sinks.Many<JSONRPCMessage> outboundSink;
+
+		private final AtomicBoolean isStarted = new AtomicBoolean(false);
+
+		/**
+         * Scheduler for handling inbound messages
+         */
+		private Scheduler inboundScheduler;
+
+		/**
+         * Scheduler for handling outbound messages
+         */
+		private Scheduler outboundScheduler;
+
+		private final Sinks.One<Void> outboundReady = Sinks.one();
+
+		public StdioMcpSessionTransport() {
+
+			this.inboundSink = Sinks.many().unicast().onBackpressureBuffer();
+			this.outboundSink = Sinks.many().unicast().onBackpressureBuffer();
+
+			// Use bounded schedulers for better resource management
+			this.inboundScheduler = Schedulers.fromExecutorService(Executors.newSingleThreadExecutor(),
+					"stdio-inbound");
+			this.outboundScheduler = Schedulers.fromExecutorService(Executors.newSingleThreadExecutor(),
+					"stdio-outbound");
+		}
+
+		@Override
+		public Mono<Void> sendMessage(McpSchema.JSONRPCMessage message) {
+
+			return Mono.zip(inboundReady.asMono(), outboundReady.asMono()).then(Mono.defer(() -> {
+				if (outboundSink.tryEmitNext(message).isSuccess()) {
+					return Mono.empty();
+				}
+				else {
+					return Mono.error(new RuntimeException("Failed to enqueue message"));
+				}
+			}));
+		}
+
+		@Override
+		public <T> T unmarshalFrom(Object data, TypeRef<T> typeRef) {
+			return jsonMapper.convertValue(data, typeRef);
+		}
+
+		@Override
+		public Mono<Void> closeGracefully() {
+			return Mono.fromRunnable(() -> {
+				isClosing.set(true);
+				logger.debug("Session transport closing gracefully");
+				inboundSink.tryEmitComplete();
+			});
+		}
+
+		@Override
+		public void close() {
+			isClosing.set(true);
+			logger.debug("Session transport closed");
+		}
+
+		public void initProcessing() {
+			handleIncomingMessages();
+			startInboundProcessing();
+			startOutboundProcessing();
+		}
+
+		private void handleIncomingMessages() {
+			this.inboundSink.asFlux().flatMap(message -> session.handle(message)).doOnTerminate(() -> {
+				// The outbound processing will dispose its scheduler upon completion
+				this.outboundSink.tryEmitComplete();
+				this.inboundScheduler.dispose();
+			}).subscribe();
+		}
+
+		/**
+         * Starts the inbound processing thread that reads JSON-RPC messages from stdin.
+         * Messages are deserialized and passed to the session for handling.
+         */
+		private void startInboundProcessing() {
+			if (isStarted.compareAndSet(false, true)) {
+				this.inboundScheduler.schedule(() -> {
+					inboundReady.tryEmitValue(null);
+					BufferedReader reader = null;
+					try {
+						reader = new BufferedReader(new InputStreamReader(inputStream));
+						while (!isClosing.get()) {
+							try {
+								String line = reader.readLine();
+								if (line == null || isClosing.get()) {
+									break;
+								}
+
+								logger.debug("Received JSON message: {}", line);
+
+								try {
+									McpSchema.JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(jsonMapper,
+											line);
+									if (!this.inboundSink.tryEmitNext(message).isSuccess()) {
+										// logIfNotClosing("Failed to enqueue message");
+										break;
+									}
+
+								}
+								catch (Exception e) {
+									logIfNotClosing("Error processing inbound message", e);
+									break;
+								}
+							}
+							catch (IOException e) {
+								logIfNotClosing("Error reading from stdin", e);
+								break;
+							}
+						}
+					}
+					catch (Exception e) {
+						logIfNotClosing("Error in inbound processing", e);
+					}
+					finally {
+						isClosing.set(true);
+						if (session != null) {
+							session.close();
+						}
+						inboundSink.tryEmitComplete();
+					}
+				});
+			}
+		}
+
+		/**
+         * Starts the outbound processing thread that writes JSON-RPC messages to stdout.
+         * Messages are serialized to JSON and written with a newline delimiter.
+         */
+		private void startOutboundProcessing() {
+			Function<Flux<JSONRPCMessage>, Flux<JSONRPCMessage>> outboundConsumer = messages -> messages // @formatter:off
+				 .doOnSubscribe(subscription -> outboundReady.tryEmitValue(null))
+				 .publishOn(outboundScheduler)
+				 .handle((message, sink) -> {
+					 if (message != null && !isClosing.get()) {
+						 try {
+							 String jsonMessage = jsonMapper.writeValueAsString(message);
+							 // Escape any embedded newlines in the JSON message as per spec
+							 jsonMessage = jsonMessage.replace("\r\n", "\\n").replace("\n", "\\n").replace("\r", "\\n");
+
+							 synchronized (outputStream) {
+								 outputStream.write(jsonMessage.getBytes(StandardCharsets.UTF_8));
+								 outputStream.write("\n".getBytes(StandardCharsets.UTF_8));
+								 outputStream.flush();
+							 }
+							 sink.next(message);
+						 }
+						 catch (IOException e) {
+							 if (!isClosing.get()) {
+								 logger.error("Error writing message", e);
+								 sink.error(new RuntimeException(e));
+							 }
+							 else {
+								 logger.debug("Stream closed during shutdown", e);
+							 }
+						 }
+					 }
+					 else if (isClosing.get()) {
+						 sink.complete();
+					 }
+				 })
+				 .doOnComplete(() -> {
+					 isClosing.set(true);
+					 outboundScheduler.dispose();
+				 })
+				 .doOnError(e -> {
+					 if (!isClosing.get()) {
+						 logger.error("Error in outbound processing", e);
+						 isClosing.set(true);
+						 outboundScheduler.dispose();
+					 }
+				 })
+				 .map(msg -> (JSONRPCMessage) msg);
+
+				 outboundConsumer.apply(outboundSink.asFlux()).subscribe();
+		 } // @formatter:on
+
+		private void logIfNotClosing(String message, Exception e) {
+			if (!isClosing.get()) {
+				logger.error(message, e);
+			}
+		}
+
+	}
+
+}

--- a/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/exceptions/JsonRrpcResponseUtilsTest.java
+++ b/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/exceptions/JsonRrpcResponseUtilsTest.java
@@ -1,0 +1,19 @@
+package io.micronaut.mcp.server.exceptions;
+
+import io.modelcontextprotocol.spec.McpError;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JsonRrpcResponseUtilsTest {
+
+    @Test
+    void errorJsonrpcResponse() {
+        McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest("2.0", "prompts/list", 3, null);
+        McpError error = new McpError("Missing handler request type: prompts/list");
+        McpSchema.JSONRPCResponse jsonrpcResponse = JsonRrpcResponseUtils.errorJsonrpcResponse(request, error);
+        assertNotNull(jsonrpcResponse);
+        assertNotNull(jsonrpcResponse.error());
+    }
+}

--- a/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/stateless/McpControllerTest.java
+++ b/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/stateless/McpControllerTest.java
@@ -1,6 +1,7 @@
 package io.micronaut.mcp.server.stateless;
 
 import io.micronaut.http.HttpStatus;
+import io.micronaut.mcp.server.exceptions.JsonRrpcResponseUtils;
 import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema;
 import org.junit.jupiter.api.Test;
@@ -38,14 +39,5 @@ class McpControllerTest {
 
         HttpStatus actual = McpController.status(jsonRpcError);
         assertEquals(expected, actual);
-    }
-
-    @Test
-    void errorJsonrpcResponse() {
-        McpSchema.JSONRPCRequest request = new McpSchema.JSONRPCRequest("2.0", "prompts/list", 3, null);
-        McpError error = new McpError("Missing handler request type: prompts/list");
-        McpSchema.JSONRPCResponse jsonrpcResponse = McpController.errorJsonrpcResponse(request, error);
-        assertNotNull(jsonrpcResponse);
-        assertNotNull(jsonrpcResponse.error());
     }
 }

--- a/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/stateless/sync/prompts/PromptsListNoPromptsCapabilityTest.java
+++ b/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/stateless/sync/prompts/PromptsListNoPromptsCapabilityTest.java
@@ -1,0 +1,39 @@
+package io.micronaut.mcp.server.stateless.sync.prompts;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.client.BlockingHttpClient;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+@Property(name = "micronaut.mcp.server.info.name", value="test mcp server")
+@Property(name = "micronaut.mcp.server.info.version", value="0.0.1")
+@Property(name = "micronaut.mcp.server.transport", value = "HTTP")
+@MicronautTest
+class PromptsListNoPromptsCapabilityTest {
+    public static final String PROMPTS_LIST = """
+        {"jsonrpc": "2.0","id": 1,"method":"prompts/list","params":{}}""";
+    public static final String PROMPTS_LIST_RESULT = """
+{"jsonrpc": "2.0","id": 1,"result": {"prompts":[]}}""";
+
+    /**
+     * Even if the server does not have the prompts capabilities, clients may not respect that and send a prompts/list request.
+     * In that scenario, the server should return an empty list of prompts
+     * @param httpClient HTTP Client
+     * @throws JSONException JSON Exception
+     */
+    @Test
+    void testResourceList(@Client("/") HttpClient httpClient) throws JSONException {
+        BlockingHttpClient client = httpClient.toBlocking();
+        HttpRequest<?> req = HttpRequest.POST("/mcp", PROMPTS_LIST);
+        String jsonRpc = assertDoesNotThrow(() -> client.retrieve(req));
+        String expected = PROMPTS_LIST_RESULT;
+        JSONAssert.assertEquals(expected, jsonRpc, true);
+    }
+}

--- a/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/stateless/sync/resources/ResourcesListNoResourcesCapabilityTest.java
+++ b/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/stateless/sync/resources/ResourcesListNoResourcesCapabilityTest.java
@@ -1,0 +1,39 @@
+package io.micronaut.mcp.server.stateless.sync.resources;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.client.BlockingHttpClient;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+@Property(name = "micronaut.mcp.server.info.name", value="test mcp server")
+@Property(name = "micronaut.mcp.server.info.version", value="0.0.1")
+@Property(name = "micronaut.mcp.server.transport", value = "HTTP")
+@MicronautTest
+class ResourcesListNoResourcesCapabilityTest {
+    public static final String RESOURCES_LIST = """
+        {"jsonrpc": "2.0","id": 1,"method":"resources/list"}""";
+    public static final String RESOURCES_LIST_RESULT = """
+{"jsonrpc": "2.0","id": 1,"result": {"resources":[]}}""";
+
+    /**
+     * Even if the server does not have the resource capabilities, clients may not respect that and send a resource/list request.
+     * In that scenario, the server should return an empty list of resources
+     * @param httpClient HTTP Client
+     * @throws JSONException JSON Exception
+     */
+    @Test
+    void testResourceList(@Client("/") HttpClient httpClient) throws JSONException {
+        BlockingHttpClient client = httpClient.toBlocking();
+        HttpRequest<?> req = HttpRequest.POST("/mcp", RESOURCES_LIST);
+        String jsonRpc = assertDoesNotThrow(() -> client.retrieve(req));
+        String expected = RESOURCES_LIST_RESULT;
+        JSONAssert.assertEquals(expected, jsonRpc, true);
+    }
+}

--- a/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/stateless/sync/tools/ToolsListNoToolsCapabilityTest.java
+++ b/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/stateless/sync/tools/ToolsListNoToolsCapabilityTest.java
@@ -1,0 +1,39 @@
+package io.micronaut.mcp.server.stateless.sync.tools;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.client.BlockingHttpClient;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+@Property(name = "micronaut.mcp.server.info.name", value="test mcp server")
+@Property(name = "micronaut.mcp.server.info.version", value="0.0.1")
+@Property(name = "micronaut.mcp.server.transport", value = "HTTP")
+@MicronautTest
+class ToolsListNoToolsCapabilityTest {
+    public static final String TOOLS_LIST = """
+        {"jsonrpc": "2.0","id": 1,"method": "tools/list"}""";
+    public static final String TOOLS_LIST_RESULT = """
+{"jsonrpc": "2.0","id": 1,"result": {"tools":[]}}""";
+
+    /**
+     * Even if the server does not have the resource capabilities, clients may not respect that and send a resource/list request.
+     * In that scenario, the server should return an empty list of resources
+     * @param httpClient HTTP Client
+     * @throws JSONException JSON Exception
+     */
+    @Test
+    void testResourceList(@Client("/") HttpClient httpClient) throws JSONException {
+        BlockingHttpClient client = httpClient.toBlocking();
+        io.micronaut.http.HttpRequest<?> req = HttpRequest.POST("/mcp", TOOLS_LIST);
+        String jsonRpc = assertDoesNotThrow(() -> client.retrieve(req));
+        String expected = TOOLS_LIST_RESULT;
+        JSONAssert.assertEquals(expected, jsonRpc, true);
+    }
+}

--- a/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/stdio/sync/StdioPromptsListNoPromptsCapabilityTest.java
+++ b/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/stdio/sync/StdioPromptsListNoPromptsCapabilityTest.java
@@ -5,16 +5,18 @@ import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Prototype;
 import io.micronaut.context.annotation.Replaces;
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.client.BlockingHttpClient;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.mcp.server.stdio.StdioServerTransportProviderReplacement;
 import io.micronaut.mcp.server.utils.Stdio;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import io.modelcontextprotocol.json.McpJsonMapper;
-import io.modelcontextprotocol.server.McpServerFeatures;
 import io.modelcontextprotocol.server.transport.StdioServerTransportProvider;
-import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpServerTransportProvider;
 import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
-import jakarta.inject.Singleton;
 import org.json.JSONException;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
@@ -27,17 +29,28 @@ import static io.micronaut.mcp.server.utils.JsonRpcMessages.EXPECTED_PROMPTS;
 import static io.micronaut.mcp.server.utils.JsonRpcMessages.INITIALIZE;
 import static io.micronaut.mcp.server.utils.JsonRpcMessages.INITIALIZED;
 import static io.micronaut.mcp.server.utils.JsonRpcMessages.PROMPTS_LIST;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@Property(name = "micronaut.mcp.server.info.name", value="world-chess-championship-2024-pgn")
+@Property(name = "micronaut.mcp.server.info.name", value="test mcp server")
 @Property(name = "micronaut.mcp.server.info.version", value="0.0.1")
 @Property(name = "micronaut.mcp.server.transport", value = "STDIO")
-@Property(name = "spec.name", value = "SyncPromptsTest")
+@Property(name = "spec.name", value = "StdioPromptsListNoPromptsCapabilityTest")
 @MicronautTest
-class SyncPromptsTest {
+class StdioPromptsListNoPromptsCapabilityTest {
+    public static final String PROMPTS_LIST = """
+        {"jsonrpc": "2.0","id": 1,"method":"prompts/list","params":{}}""";
+    public static final String PROMPTS_LIST_RESULT = """
+{"jsonrpc": "2.0","id": 1,"result": {"prompts":[]}}""";
+
+
     @Inject
     ReplacementMcpServerTransportProviderFactory factory;
 
+    /**
+     * Even if the server does not have the prompts capabilities, clients may not respect that and send a prompts/list request.
+     * In that scenario, the server should return an empty list of prompts
+     */
     @SuppressWarnings("java:S2925")
     @Test
     void syncPrompts() throws IOException, InterruptedException, JSONException {
@@ -50,28 +63,10 @@ class SyncPromptsTest {
         List<String> responses = factory.stdio.readResponses();
         assertEquals(2, responses.size());
         String readJsonRpc = responses.get(1);
-        JSONAssert.assertEquals(EXPECTED_PROMPTS, readJsonRpc, true);
+        JSONAssert.assertEquals(PROMPTS_LIST_RESULT, readJsonRpc, true);
     }
 
-    @Requires(property = "spec.name", value = "SyncPromptsTest")
-    @Factory
-    static class AsyncPromptsFactory {
-        @Singleton
-        McpServerFeatures.SyncPromptSpecification prompt() {
-            return new McpServerFeatures.SyncPromptSpecification(
-                new McpSchema.Prompt("chess-statistics", "Displays statistics for chess games",
-                    List.of(new McpSchema.PromptArgument("name", "Player Name", true))), (ex, req) -> {
-                Object playerNameObj = req.arguments().get("name");
-                String playerName = playerNameObj != null ? playerNameObj.toString() : "";
-                McpSchema.TextContent assistantContent = new McpSchema.TextContent(String.format("""
-                                        You generate chess statistics for %s ....""", playerName));
-                McpSchema.PromptMessage assistantMessage = new McpSchema.PromptMessage(McpSchema.Role.ASSISTANT, assistantContent);
-                return new McpSchema.GetPromptResult("Chess statistics", List.of(assistantMessage), null);
-            });
-        }
-    }
-
-    @Requires(property = "spec.name", value = "SyncPromptsTest")
+    @Requires(property = "spec.name", value = "StdioPromptsListNoPromptsCapabilityTest")
     @Factory
     static class ReplacementMcpServerTransportProviderFactory implements AutoCloseable {
         public final Stdio stdio = new Stdio();
@@ -79,7 +74,7 @@ class SyncPromptsTest {
         @Prototype
         @Replaces(McpServerTransportProvider.class)
         McpServerTransportProvider stdioServerTransportProviderReplacement(McpJsonMapper jsonMapper) {
-            return new StdioServerTransportProvider(jsonMapper, stdio.serverStdin, stdio.serverStdout);
+            return new StdioServerTransportProviderReplacement(jsonMapper, stdio.serverStdin, stdio.serverStdout);
         }
 
         @PreDestroy

--- a/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/stdio/sync/StdioResourcesListNoResourcesCapabilityTest.java
+++ b/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/stdio/sync/StdioResourcesListNoResourcesCapabilityTest.java
@@ -5,16 +5,13 @@ import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Prototype;
 import io.micronaut.context.annotation.Replaces;
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.mcp.server.stdio.StdioServerTransportProviderReplacement;
 import io.micronaut.mcp.server.utils.Stdio;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import io.modelcontextprotocol.json.McpJsonMapper;
-import io.modelcontextprotocol.server.McpServerFeatures;
-import io.modelcontextprotocol.server.transport.StdioServerTransportProvider;
-import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpServerTransportProvider;
 import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
-import jakarta.inject.Singleton;
 import org.json.JSONException;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
@@ -23,21 +20,28 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static io.micronaut.mcp.server.utils.JsonRpcMessages.EXPECTED_PROMPTS;
 import static io.micronaut.mcp.server.utils.JsonRpcMessages.INITIALIZE;
 import static io.micronaut.mcp.server.utils.JsonRpcMessages.INITIALIZED;
-import static io.micronaut.mcp.server.utils.JsonRpcMessages.PROMPTS_LIST;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@Property(name = "micronaut.mcp.server.info.name", value="world-chess-championship-2024-pgn")
+@Property(name = "micronaut.mcp.server.info.name", value="test mcp server")
 @Property(name = "micronaut.mcp.server.info.version", value="0.0.1")
 @Property(name = "micronaut.mcp.server.transport", value = "STDIO")
-@Property(name = "spec.name", value = "SyncPromptsTest")
+@Property(name = "spec.name", value = "StdioResourcesListNoResourcesCapabilityTest")
 @MicronautTest
-class SyncPromptsTest {
+class StdioResourcesListNoResourcesCapabilityTest {
+    public static final String RESOURCES_LIST = """
+        {"jsonrpc": "2.0","id": 1,"method":"resources/list"}""";
+    public static final String RESOURCES_LIST_RESULT = """
+{"jsonrpc": "2.0","id": 1,"result": {"resources":[]}}""";
+
     @Inject
     ReplacementMcpServerTransportProviderFactory factory;
 
+    /**
+     * Even if the server does not have the prompts capabilities, clients may not respect that and send a prompts/list request.
+     * In that scenario, the server should return an empty list of prompts
+     */
     @SuppressWarnings("java:S2925")
     @Test
     void syncPrompts() throws IOException, InterruptedException, JSONException {
@@ -45,33 +49,15 @@ class SyncPromptsTest {
         Thread.sleep(TimeUnit.SECONDS.toMillis(1));
         factory.stdio.sendRequest(INITIALIZED);
         Thread.sleep(TimeUnit.SECONDS.toMillis(1));
-        factory.stdio.sendRequest(PROMPTS_LIST);
+        factory.stdio.sendRequest(RESOURCES_LIST);
         Thread.sleep(TimeUnit.SECONDS.toMillis(1));
         List<String> responses = factory.stdio.readResponses();
         assertEquals(2, responses.size());
         String readJsonRpc = responses.get(1);
-        JSONAssert.assertEquals(EXPECTED_PROMPTS, readJsonRpc, true);
+        JSONAssert.assertEquals(RESOURCES_LIST_RESULT, readJsonRpc, true);
     }
 
-    @Requires(property = "spec.name", value = "SyncPromptsTest")
-    @Factory
-    static class AsyncPromptsFactory {
-        @Singleton
-        McpServerFeatures.SyncPromptSpecification prompt() {
-            return new McpServerFeatures.SyncPromptSpecification(
-                new McpSchema.Prompt("chess-statistics", "Displays statistics for chess games",
-                    List.of(new McpSchema.PromptArgument("name", "Player Name", true))), (ex, req) -> {
-                Object playerNameObj = req.arguments().get("name");
-                String playerName = playerNameObj != null ? playerNameObj.toString() : "";
-                McpSchema.TextContent assistantContent = new McpSchema.TextContent(String.format("""
-                                        You generate chess statistics for %s ....""", playerName));
-                McpSchema.PromptMessage assistantMessage = new McpSchema.PromptMessage(McpSchema.Role.ASSISTANT, assistantContent);
-                return new McpSchema.GetPromptResult("Chess statistics", List.of(assistantMessage), null);
-            });
-        }
-    }
-
-    @Requires(property = "spec.name", value = "SyncPromptsTest")
+    @Requires(property = "spec.name", value = "StdioResourcesListNoResourcesCapabilityTest")
     @Factory
     static class ReplacementMcpServerTransportProviderFactory implements AutoCloseable {
         public final Stdio stdio = new Stdio();
@@ -79,7 +65,7 @@ class SyncPromptsTest {
         @Prototype
         @Replaces(McpServerTransportProvider.class)
         McpServerTransportProvider stdioServerTransportProviderReplacement(McpJsonMapper jsonMapper) {
-            return new StdioServerTransportProvider(jsonMapper, stdio.serverStdin, stdio.serverStdout);
+            return new StdioServerTransportProviderReplacement(jsonMapper, stdio.serverStdin, stdio.serverStdout);
         }
 
         @PreDestroy

--- a/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/stdio/sync/StdioToolsListNoToolsCapabilityTest.java
+++ b/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/stdio/sync/StdioToolsListNoToolsCapabilityTest.java
@@ -5,16 +5,13 @@ import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Prototype;
 import io.micronaut.context.annotation.Replaces;
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.mcp.server.stdio.StdioServerTransportProviderReplacement;
 import io.micronaut.mcp.server.utils.Stdio;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import io.modelcontextprotocol.json.McpJsonMapper;
-import io.modelcontextprotocol.server.McpServerFeatures;
-import io.modelcontextprotocol.server.transport.StdioServerTransportProvider;
-import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpServerTransportProvider;
 import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
-import jakarta.inject.Singleton;
 import org.json.JSONException;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
@@ -23,21 +20,28 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static io.micronaut.mcp.server.utils.JsonRpcMessages.EXPECTED_PROMPTS;
 import static io.micronaut.mcp.server.utils.JsonRpcMessages.INITIALIZE;
 import static io.micronaut.mcp.server.utils.JsonRpcMessages.INITIALIZED;
-import static io.micronaut.mcp.server.utils.JsonRpcMessages.PROMPTS_LIST;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@Property(name = "micronaut.mcp.server.info.name", value="world-chess-championship-2024-pgn")
+@Property(name = "micronaut.mcp.server.info.name", value="test mcp server")
 @Property(name = "micronaut.mcp.server.info.version", value="0.0.1")
 @Property(name = "micronaut.mcp.server.transport", value = "STDIO")
-@Property(name = "spec.name", value = "SyncPromptsTest")
+@Property(name = "spec.name", value = "StdioToolsListNoToolsCapabilityTest")
 @MicronautTest
-class SyncPromptsTest {
+class StdioToolsListNoToolsCapabilityTest {
+    public static final String TOOLS_LIST = """
+        {"jsonrpc": "2.0","id": 1,"method": "tools/list"}""";
+    public static final String TOOLS_LIST_RESULT = """
+{"jsonrpc": "2.0","id": 1,"result": {"tools":[]}}""";
+
     @Inject
     ReplacementMcpServerTransportProviderFactory factory;
 
+    /**
+     * Even if the server does not have the prompts capabilities, clients may not respect that and send a prompts/list request.
+     * In that scenario, the server should return an empty list of prompts
+     */
     @SuppressWarnings("java:S2925")
     @Test
     void syncPrompts() throws IOException, InterruptedException, JSONException {
@@ -45,33 +49,15 @@ class SyncPromptsTest {
         Thread.sleep(TimeUnit.SECONDS.toMillis(1));
         factory.stdio.sendRequest(INITIALIZED);
         Thread.sleep(TimeUnit.SECONDS.toMillis(1));
-        factory.stdio.sendRequest(PROMPTS_LIST);
+        factory.stdio.sendRequest(TOOLS_LIST);
         Thread.sleep(TimeUnit.SECONDS.toMillis(1));
         List<String> responses = factory.stdio.readResponses();
         assertEquals(2, responses.size());
         String readJsonRpc = responses.get(1);
-        JSONAssert.assertEquals(EXPECTED_PROMPTS, readJsonRpc, true);
+        JSONAssert.assertEquals(TOOLS_LIST_RESULT, readJsonRpc, true);
     }
 
-    @Requires(property = "spec.name", value = "SyncPromptsTest")
-    @Factory
-    static class AsyncPromptsFactory {
-        @Singleton
-        McpServerFeatures.SyncPromptSpecification prompt() {
-            return new McpServerFeatures.SyncPromptSpecification(
-                new McpSchema.Prompt("chess-statistics", "Displays statistics for chess games",
-                    List.of(new McpSchema.PromptArgument("name", "Player Name", true))), (ex, req) -> {
-                Object playerNameObj = req.arguments().get("name");
-                String playerName = playerNameObj != null ? playerNameObj.toString() : "";
-                McpSchema.TextContent assistantContent = new McpSchema.TextContent(String.format("""
-                                        You generate chess statistics for %s ....""", playerName));
-                McpSchema.PromptMessage assistantMessage = new McpSchema.PromptMessage(McpSchema.Role.ASSISTANT, assistantContent);
-                return new McpSchema.GetPromptResult("Chess statistics", List.of(assistantMessage), null);
-            });
-        }
-    }
-
-    @Requires(property = "spec.name", value = "SyncPromptsTest")
+    @Requires(property = "spec.name", value = "StdioToolsListNoToolsCapabilityTest")
     @Factory
     static class ReplacementMcpServerTransportProviderFactory implements AutoCloseable {
         public final Stdio stdio = new Stdio();
@@ -79,7 +65,7 @@ class SyncPromptsTest {
         @Prototype
         @Replaces(McpServerTransportProvider.class)
         McpServerTransportProvider stdioServerTransportProviderReplacement(McpJsonMapper jsonMapper) {
-            return new StdioServerTransportProvider(jsonMapper, stdio.serverStdin, stdio.serverStdout);
+            return new StdioServerTransportProviderReplacement(jsonMapper, stdio.serverStdin, stdio.serverStdout);
         }
 
         @PreDestroy

--- a/test-suite-graal/src/test/java/example/micronaut/mcp/PromptsListTest.java
+++ b/test-suite-graal/src/test/java/example/micronaut/mcp/PromptsListTest.java
@@ -1,6 +1,7 @@
 package example.micronaut.mcp;
 
 import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.client.BlockingHttpClient;
 import io.micronaut.http.client.HttpClient;
@@ -13,7 +14,6 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @MicronautTest
@@ -29,15 +29,14 @@ class PromptsListTest {
     @Test
     void promptsList(@Client("/") HttpClient httpClient) {
         BlockingHttpClient client = httpClient.toBlocking();
-        HttpClientResponseException ex = assertThrows(HttpClientResponseException.class,
-            () -> client.exchange(HttpRequest.POST("/mcp", """
+        HttpResponse<String> rsp = assertDoesNotThrow(() -> client.exchange(HttpRequest.POST("/mcp", """
                 {"jsonrpc":"2.0","id":2,"method":"prompts/list","params":{}}"""), String.class));
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, ex.getStatus());
-        Optional<String> jsonOptional = ex.getResponse().getBody(String.class);
+        assertEquals(rsp.getStatus(), HttpStatus.OK);
+        Optional<String> jsonOptional = rsp.getBody(String.class);
         assertTrue(jsonOptional.isPresent());
         String json = jsonOptional.get();
         String expected = """
-            {"jsonrpc":"2.0","id":2,"error":{"code":-32603,"message":"Missing handler for request type: prompts/list"}}""";
+            {"jsonrpc":"2.0","id":2,"result":{"prompts":[]}}""";
         assertEquals(expected, json);
     }
 }


### PR DESCRIPTION
Some clients will do tools/list prompts/list requests even if the capabilities of the server don’t include those primitives. This change handles those requests graciously.