### PR TITLE
Tool annotations

### DIFF
--- a/micronaut-mcp-annotations/src/main/java/io/micronaut/mcp/annotations/Tool.java
+++ b/micronaut-mcp-annotations/src/main/java/io/micronaut/mcp/annotations/Tool.java
@@ -63,7 +63,7 @@ public @interface Tool {
      * explicitly in order to be included in Tool metadata.
      * @return Additional hints for clients.
      */
-    Annotations annotations() default @Annotations;
+    ToolAnnotations annotations() default @ToolAnnotations;
 
     /**
      * Additional hints for clients.
@@ -71,7 +71,7 @@ public @interface Tool {
      */
     @Retention(RUNTIME)
     @Target(ElementType.ANNOTATION_TYPE)
-    @interface Annotations {
+    @interface ToolAnnotations {
 
         /**
          * @return A human-readable title for the tool.

--- a/micronaut-mcp-annotations/src/main/java/io/micronaut/mcp/annotations/Tool.java
+++ b/micronaut-mcp-annotations/src/main/java/io/micronaut/mcp/annotations/Tool.java
@@ -16,6 +16,7 @@
 package io.micronaut.mcp.annotations;
 
 import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
@@ -54,4 +55,54 @@ public @interface Tool {
      * @return A human-readable description of the tool. A hint to the model.
      */
     String description() default "";
+
+    /**
+     * Additional hints for clients.
+     * <p>
+     * Note that the default value of this annotation member is ignored. In other words, the annotations have to be declared
+     * explicitly in order to be included in Tool metadata.
+     * @return Additional hints for clients.
+     */
+    Annotations annotations() default @Annotations;
+
+    /**
+     * Additional hints for clients.
+     * <a href="https://modelcontextprotocol.io/specification/2025-06-18/schema#toolannotations">Tool Annotations</a>
+     */
+    @Retention(RUNTIME)
+    @Target(ElementType.ANNOTATION_TYPE)
+    @interface Annotations {
+
+        /**
+         * @return A human-readable title for the tool.
+         */
+        String title() default "";
+
+        /**
+         * @return If true, the tool does not modify its environment.
+         */
+        boolean readOnlyHint() default false;
+
+        /**
+         * @return If true, the tool may perform destructive updates to its environment. If false, the tool performs only additive
+         * updates.
+         */
+        boolean destructiveHint() default true;
+
+        /**
+         * @return If true, calling the tool repeatedly with the same arguments will have no additional effect on the its environment.
+         */
+        boolean idempotentHint() default false;
+
+        /**
+         * @return If true, this tool may interact with an "open world" of external entities. If false, the tool's domain of interaction
+         * is closed.
+         */
+        boolean openWorldHint() default true;
+
+        /**
+         * @return It tells the client/agent whether the tool's result can be surfaced to the end user immediately (as the assistant reply) without another model turn.
+         */
+        boolean returnDirect() default false;
+    }
 }

--- a/micronaut-mcp-server-java-sdk/src/main/java/io/micronaut/mcp/server/registry/ToolRegistry.java
+++ b/micronaut-mcp-server-java-sdk/src/main/java/io/micronaut/mcp/server/registry/ToolRegistry.java
@@ -65,9 +65,29 @@ import static io.micronaut.mcp.server.registry.JsonSchemaUtils.TYPE_STRING;
 @Singleton
 @Internal
 public final class ToolRegistry extends AbstractMcpMethodRegistry<McpServerFeatures.SyncToolSpecification, McpServerFeatures.AsyncToolSpecification, McpStatelessServerFeatures.SyncToolSpecification, McpStatelessServerFeatures.AsyncToolSpecification> {
+    public static final boolean DEFAULT_IDEMPOTENT_HINT_VALUE = false;
+    public static final boolean DEFAULT_OPEN_WORLD_HINT_VALUE = true;
+    public static final boolean DEFAULT_RETURN_DIRECT_VALUE = false;
     private static final Logger LOG = LoggerFactory.getLogger(ToolRegistry.class);
     private static final List<Class<?>> BINDABLE_PARAMETER_TYPES = List.of(McpTransportContext.class,
         McpSchema.CallToolRequest.class);
+    private static final String MEMBER_ANNOTATIONS = "annotations";
+    private static final String MEMBER_READ_ONLY_HINT = "readOnlyHint";
+    private static final String MEMBER_DESTRUCTIVE_HINT = "destructiveHint";
+    private static final String MEMBER_IDEMPOTENT_HINT = "idempotentHint";
+    private static final String MEMBER_OPEN_WORLD_HINT = "openWorldHint";
+    private static final String METHOD_RETURN_DIRECT = "returnDirect";
+    private static final String DEFAULT_TOOL_ANNOTATION_MEMBER_TITLE_VALUE = "";
+    private static final boolean DEFAULT_MEMBER_READ_ONLY_HINT_VALUE = false;
+    private static final boolean DEFAULT_MEMBER_DESTRUCTIVE_HINT_VALUE = true;
+    private static final McpSchema.ToolAnnotations DEFAULT_TOOL_ANNOTATIONS = new McpSchema.ToolAnnotations(
+        DEFAULT_TOOL_ANNOTATION_MEMBER_TITLE_VALUE,
+        DEFAULT_MEMBER_READ_ONLY_HINT_VALUE,
+        DEFAULT_MEMBER_DESTRUCTIVE_HINT_VALUE,
+        DEFAULT_IDEMPOTENT_HINT_VALUE,
+        DEFAULT_OPEN_WORLD_HINT_VALUE,
+        DEFAULT_RETURN_DIRECT_VALUE
+    );
     private final JsonSchemaClassPathResourceLoader jsonSchemaClassPathResourceLoader;
     private final McpJsonMapper mcpJsonMapper;
     private final JsonMapper jsonMapper;
@@ -201,6 +221,7 @@ public final class ToolRegistry extends AbstractMcpMethodRegistry<McpServerFeatu
             .name(toolName(method));
         toolTitle(method).ifPresent(toolBuilder::title);
         toolDescription(method).ifPresent(toolBuilder::description);
+        toolAnnotations(method).ifPresent(toolBuilder::annotations);
         Optional<Argument<?>> jsonSchemaArgumentOptional = jsonSchemaArgument(method);
         String jsonSchema = jsonSchemaArgumentOptional.flatMap(this::jsonSchema).orElse(null);
         if (jsonSchema != null) {
@@ -228,6 +249,19 @@ public final class ToolRegistry extends AbstractMcpMethodRegistry<McpServerFeatu
 
     private static Optional<String> toolTitle(ExecutableMethod<?, ?> method) {
         return method.stringValue(Tool.class, MEMBER_TITLE);
+    }
+
+    private static Optional<McpSchema.ToolAnnotations> toolAnnotations(ExecutableMethod<?, ?> method) {
+        return method.findAnnotation(Tool.class)
+            .flatMap(toolAnnotationValue -> toolAnnotationValue.getAnnotation(MEMBER_ANNOTATIONS))
+            .map(annotationAnnotationValue -> new McpSchema.ToolAnnotations(
+                annotationAnnotationValue.stringValue(MEMBER_TITLE).orElse(DEFAULT_TOOL_ANNOTATION_MEMBER_TITLE_VALUE),
+                    annotationAnnotationValue.booleanValue(MEMBER_READ_ONLY_HINT).orElse(DEFAULT_MEMBER_READ_ONLY_HINT_VALUE),
+                    annotationAnnotationValue.booleanValue(MEMBER_DESTRUCTIVE_HINT).orElse(DEFAULT_MEMBER_DESTRUCTIVE_HINT_VALUE),
+                    annotationAnnotationValue.booleanValue(MEMBER_IDEMPOTENT_HINT).orElse(DEFAULT_IDEMPOTENT_HINT_VALUE),
+                    annotationAnnotationValue.booleanValue(MEMBER_OPEN_WORLD_HINT).orElse(DEFAULT_OPEN_WORLD_HINT_VALUE),
+                    annotationAnnotationValue.booleanValue(METHOD_RETURN_DIRECT).orElse(DEFAULT_RETURN_DIRECT_VALUE)
+            )).filter(toolAnnotations -> !toolAnnotations.equals(DEFAULT_TOOL_ANNOTATIONS));
     }
 
     private static Optional<String> toolDescription(ExecutableMethod<?, ?> method) {

--- a/micronaut-mcp-server-java-sdk/src/main/java/io/micronaut/mcp/server/tools/fetch/FetchToolFactory.java
+++ b/micronaut-mcp-server-java-sdk/src/main/java/io/micronaut/mcp/server/tools/fetch/FetchToolFactory.java
@@ -33,6 +33,10 @@ import reactor.core.publisher.Mono;
 
 import java.util.Optional;
 
+import static io.micronaut.mcp.server.registry.ToolRegistry.DEFAULT_IDEMPOTENT_HINT_VALUE;
+import static io.micronaut.mcp.server.registry.ToolRegistry.DEFAULT_OPEN_WORLD_HINT_VALUE;
+import static io.micronaut.mcp.server.registry.ToolRegistry.DEFAULT_RETURN_DIRECT_VALUE;
+
 /**
  * Factory to create beans of type {@link McpServerFeatures.SyncToolSpecification}, {@link McpServerFeatures.AsyncToolSpecification}, {@link McpStatelessServerFeatures.SyncToolSpecification}, and {@link McpStatelessServerFeatures.AsyncToolSpecification} given a bean of type {@link FetchTool}.
  */
@@ -50,6 +54,7 @@ final class FetchToolFactory {
             .name(tool.getName())
             .title(tool.getTitle())
             .description(tool.getDescription())
+            .annotations(toolAnnotations(tool))
             .inputSchema(mcpJsonMapper, jsonSchemaClassPathResourceLoader.jsonSchemaStringForClass(FetchRequest.class)
                 .orElseThrow(() -> new ConfigurationException("JSON Schema not found for FetchRequest")))
             .outputSchema(mcpJsonMapper, jsonSchemaClassPathResourceLoader.jsonSchemaStringForClass(FetchResponse.class)
@@ -153,5 +158,14 @@ final class FetchToolFactory {
                 .isError(true)
                 .build();
         }
+    }
+
+    private static McpSchema.ToolAnnotations toolAnnotations(FetchTool tool) {
+        boolean readOnlyHint = true;
+        boolean destructiveHint = false;
+        boolean idempotentHint = DEFAULT_IDEMPOTENT_HINT_VALUE;
+        boolean openWorldHint = DEFAULT_OPEN_WORLD_HINT_VALUE;
+        boolean returnDirect = DEFAULT_RETURN_DIRECT_VALUE;
+        return new McpSchema.ToolAnnotations(tool.getTitle(), readOnlyHint, destructiveHint, idempotentHint, openWorldHint, returnDirect);
     }
 }

--- a/micronaut-mcp-server-java-sdk/src/main/java/io/micronaut/mcp/server/tools/search/SearchToolFactory.java
+++ b/micronaut-mcp-server-java-sdk/src/main/java/io/micronaut/mcp/server/tools/search/SearchToolFactory.java
@@ -31,6 +31,10 @@ import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 import reactor.core.publisher.Mono;
 
+import static io.micronaut.mcp.server.registry.ToolRegistry.DEFAULT_IDEMPOTENT_HINT_VALUE;
+import static io.micronaut.mcp.server.registry.ToolRegistry.DEFAULT_OPEN_WORLD_HINT_VALUE;
+import static io.micronaut.mcp.server.registry.ToolRegistry.DEFAULT_RETURN_DIRECT_VALUE;
+
 /**
  * Factory to create beans of type {@link McpServerFeatures.SyncToolSpecification}, {@link McpServerFeatures.AsyncToolSpecification}, {@link McpStatelessServerFeatures.SyncToolSpecification}, and {@link McpStatelessServerFeatures.AsyncToolSpecification} given a bean of type {@link SearchTool}.
  */
@@ -48,6 +52,7 @@ final class SearchToolFactory {
                 .name(tool.getName())
                 .title(tool.getTitle())
                 .description(tool.getDescription())
+                .annotations(toolAnnotations(tool))
                 .inputSchema(mcpJsonMapper, jsonSchemaClassPathResourceLoader.jsonSchemaStringForClass(SearchRequest.class)
                     .orElseThrow(() -> new ConfigurationException("JSON Schema not found for SearchRequest")))
                 .outputSchema(mcpJsonMapper, jsonSchemaClassPathResourceLoader.jsonSchemaStringForClass(SearchResponse.class)
@@ -142,5 +147,14 @@ final class SearchToolFactory {
                     .isError(true)
                     .build();
         }
+    }
+
+    private static McpSchema.ToolAnnotations toolAnnotations(SearchTool tool) {
+        boolean readOnlyHint = true;
+        boolean destructiveHint = false;
+        boolean idempotentHint = DEFAULT_IDEMPOTENT_HINT_VALUE;
+        boolean openWorldHint = DEFAULT_OPEN_WORLD_HINT_VALUE;
+        boolean returnDirect = DEFAULT_RETURN_DIRECT_VALUE;
+        return new McpSchema.ToolAnnotations(tool.getTitle(), readOnlyHint, destructiveHint, idempotentHint, openWorldHint, returnDirect);
     }
 }

--- a/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/stateless/sync/prompts/StatelessSyncPromptsToolAnnotationsTest.java
+++ b/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/stateless/sync/prompts/StatelessSyncPromptsToolAnnotationsTest.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @Property(name = "micronaut.mcp.server.transport", value = "HTTP")
 @Property(name = "spec.name", value = "StatelessSyncPromptsAnnotationsTest")
 @MicronautTest
-class StatelessSyncPromptsAnnotationsTest {
+class StatelessSyncPromptsToolAnnotationsTest {
 
     @Test
     void statelessSyncPromptsList(@Client("/") HttpClient httpClient) throws JSONException {

--- a/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/stateless/sync/resources/StatelessSyncResourcesBinaryToolAnnotationsTest.java
+++ b/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/stateless/sync/resources/StatelessSyncResourcesBinaryToolAnnotationsTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Property(name = "micronaut.mcp.server.transport", value = "HTTP")
 @Property(name = "spec.name", value = "StatelessSyncResourcesBinaryAnnotationsTest")
 @MicronautTest
-class StatelessSyncResourcesBinaryAnnotationsTest {
+class StatelessSyncResourcesBinaryToolAnnotationsTest {
 
     @Test
     void resourcesListContainsZip(@Client("/") HttpClient httpClient) throws JSONException {

--- a/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/stateless/sync/resources/StatelessSyncResourcesToolAnnotationsTest.java
+++ b/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/stateless/sync/resources/StatelessSyncResourcesToolAnnotationsTest.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 @Property(name = "micronaut.mcp.server.transport", value = "HTTP")
 @Property(name = "spec.name", value = "StatelessSyncResourcesAnnotationsTest")
 @MicronautTest
-class StatelessSyncResourcesAnnotationsTest {
+class StatelessSyncResourcesToolAnnotationsTest {
 
     @Test
     void resourcesList(@Client("/") HttpClient httpClient) throws JSONException {

--- a/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/stateless/sync/tools/HelloWorldTool.java
+++ b/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/stateless/sync/tools/HelloWorldTool.java
@@ -1,0 +1,23 @@
+package io.micronaut.mcp.server.stateless.sync.tools;
+
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.mcp.annotations.Tool;
+import jakarta.inject.Singleton;
+
+@Requires(property = "spec.name", value = "ToolAnnotationsTest")
+//tag::clazz[]
+@Singleton
+class HelloWorldTool {
+    @Tool(title = "Hello World",
+        annotations = @Tool.Annotations(readOnlyHint = true,
+            title = "Hello World",
+            destructiveHint = false,
+            idempotentHint = true,
+            openWorldHint = false,
+            returnDirect = true))
+    String helloWorld() {
+        return "Hello, World!";
+    }
+}
+//end::clazz[]

--- a/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/stateless/sync/tools/HelloWorldTool.java
+++ b/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/stateless/sync/tools/HelloWorldTool.java
@@ -10,7 +10,7 @@ import jakarta.inject.Singleton;
 @Singleton
 class HelloWorldTool {
     @Tool(title = "Hello World",
-        annotations = @Tool.Annotations(readOnlyHint = true,
+        annotations = @Tool.ToolAnnotations(readOnlyHint = true,
             title = "Hello World",
             destructiveHint = false,
             idempotentHint = true,

--- a/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/stateless/sync/tools/StatelessSyncToolsToolAnnotationsObjectReturnTest.java
+++ b/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/stateless/sync/tools/StatelessSyncToolsToolAnnotationsObjectReturnTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 @Property(name = "micronaut.mcp.server.transport", value = "HTTP")
 @Property(name = "spec.name", value = "StatelessSyncToolsAnnotationsObjectReturnTest")
 @MicronautTest
-class StatelessSyncToolsAnnotationsObjectReturnTest {
+class StatelessSyncToolsToolAnnotationsObjectReturnTest {
     @Test
     void toolsCall(@Client("/") HttpClient httpClient) throws JSONException {
         BlockingHttpClient client = httpClient.toBlocking();

--- a/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/stateless/sync/tools/StatelessSyncToolsToolAnnotationsTest.java
+++ b/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/stateless/sync/tools/StatelessSyncToolsToolAnnotationsTest.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 @Property(name = "micronaut.mcp.server.transport", value = "HTTP")
 @Property(name = "spec.name", value = "StatelessSyncToolAnnotationTest")
 @MicronautTest
-class StatelessSyncToolsAnnotationsTest {
+class StatelessSyncToolsToolAnnotationsTest {
 
     @Test
     void toolsList(@Client("/") HttpClient httpClient) throws JSONException {

--- a/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/stateless/sync/tools/ToolAnnotationsTest.java
+++ b/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/stateless/sync/tools/ToolAnnotationsTest.java
@@ -1,0 +1,33 @@
+package io.micronaut.mcp.server.stateless.sync.tools;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.client.BlockingHttpClient;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.mcp.annotations.Tool;
+import io.micronaut.mcp.server.tools.fetch.FetchTool;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.modelcontextprotocol.spec.McpSchema;
+import jakarta.inject.Singleton;
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+
+import static io.micronaut.mcp.server.utils.JsonRpcMessages.TOOLS_LIST;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Property(name = "micronaut.mcp.server.info.name", value = "mcp-server")
+@Property(name = "micronaut.mcp.server.info.version", value = "0.0.1")
+@Property(name = "micronaut.mcp.server.transport", value = "HTTP")
+@Property(name = "spec.name", value = "ToolAnnotationsTest")
+@MicronautTest
+class ToolAnnotationsTest {
+
+    @Test
+    void toolAnnotationsTest(@Client("/") HttpClient httpClient) throws JSONException {
+        BlockingHttpClient client = httpClient.toBlocking();
+        String json = assertDoesNotThrow(() -> client.retrieve(HttpRequest.POST("/mcp", TOOLS_LIST)));
+        assertTrue(json.contains(",\"annotations\":{\"title\":\"Hello World\",\"readOnlyHint\":true,\"destructiveHint\":false,\"idempotentHint\":true,\"openWorldHint\":false,\"returnDirect\":true}}]}}"), json);
+    }
+}

--- a/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/stateless/sync/tools/ToolToolAnnotationsTest.java
+++ b/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/stateless/sync/tools/ToolToolAnnotationsTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @Property(name = "micronaut.mcp.server.transport", value = "HTTP")
 @Property(name = "spec.name", value = "ToolAnnotationsTest")
 @MicronautTest
-class ToolAnnotationsTest {
+class ToolToolAnnotationsTest {
 
     @Test
     void toolAnnotationsTest(@Client("/") HttpClient httpClient) throws JSONException {

--- a/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/tools/fetch/FetchToolFactoryHttpTest.java
+++ b/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/tools/fetch/FetchToolFactoryHttpTest.java
@@ -12,8 +12,8 @@ import org.json.JSONException;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static io.micronaut.mcp.server.utils.JsonRpcMessages.TOOLS_LIST;
+import static org.junit.jupiter.api.Assertions.*;
 
 @Property(name = "micronaut.mcp.server.info.name", value = "mcp-server")
 @Property(name = "micronaut.mcp.server.info.version", value = "0.0.1")
@@ -29,6 +29,9 @@ class FetchToolFactoryHttpTest {
         assertEquals("Fetch", tool.getTitle());
         assertEquals("This tool retrieves the full contents of a search result document or item.", tool.getDescription());
         BlockingHttpClient client = httpClient.toBlocking();
+        String json = assertDoesNotThrow(() -> client.retrieve(HttpRequest.POST("/mcp", TOOLS_LIST)));
+        assertTrue(json.contains(",\"annotations\":{\"title\":\"Fetch\",\"readOnlyHint\":true,\"destructiveHint\":false,\"idempotentHint\":false,\"openWorldHint\":true,\"returnDirect\":false}}]}}"), json);
+
         HttpRequest<?> req = HttpRequest.POST("/mcp", """
             {
               "method": "tools/call",

--- a/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/tools/search/SearchToolFactoryHttpTest.java
+++ b/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/tools/search/SearchToolFactoryHttpTest.java
@@ -13,6 +13,7 @@ import org.json.JSONException;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
+import static io.micronaut.mcp.server.utils.JsonRpcMessages.TOOLS_LIST;
 import static org.junit.jupiter.api.Assertions.*;
 
 @Property(name = "micronaut.mcp.server.info.name", value = "mcp-server")
@@ -25,10 +26,13 @@ class SearchToolFactoryHttpTest {
 
     @Test
     void searchTool(@Client("/") HttpClient httpClient, SearchTool tool) throws JSONException {
+        BlockingHttpClient client = httpClient.toBlocking();
         assertEquals("search", tool.getName());
         assertEquals("Search", tool.getTitle());
         assertEquals("Returns a list of relevant search results, given a user's query.", tool.getDescription());
-        BlockingHttpClient client = httpClient.toBlocking();
+        String json = assertDoesNotThrow(() -> client.retrieve(HttpRequest.POST("/mcp", TOOLS_LIST)));
+        assertTrue(json.contains(",\"annotations\":{\"title\":\"Search\",\"readOnlyHint\":true,\"destructiveHint\":false,\"idempotentHint\":false,\"openWorldHint\":true,\"returnDirect\":false}}]}}"), json);
+
         HttpRequest<?> req = HttpRequest.POST("/mcp", """
             {
               "method": "tools/call",

--- a/src/main/docs/guide/server/primitives/tools/toolAnnotation/toolAnnotationsHints.adoc
+++ b/src/main/docs/guide/server/primitives/tools/toolAnnotation/toolAnnotationsHints.adoc
@@ -1,0 +1,7 @@
+You can use annotation hints to inform the client that a tool is read-only.
+ChatGPT, for example, informs users whether a tool performs write operations.
+
+[source, java]
+----
+include::micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/stateless/sync/tools/HelloWorldTool.java[tags="clazz",indent=0]
+----

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -26,6 +26,7 @@ server:
       fetch: Fetch Tool
       toolAnnotation:
         title: Tools with Annotations
+        toolAnnotationsHints: Tool Hints
         toolAnnotationParameter: Tool Annotation Method Parameters
         toolAnnotationReturnType: Tool Annotation Method Return Type
       toolsInputJsonSchema: Tools Input JSON Schema


### PR DESCRIPTION
https://modelcontextprotocol.io/specification/2025-06-18/schema#toolannotations

Some clients such as ChatGPT will use these hints to display information. For example, ChatGTP tells the user whether a tool writes.