### PR TITLE
bug: ReadResourceResult serde issue

### DIFF
--- a/micronaut-mcp-client-java-sdk/src/main/java/io/micronaut/mcp/client/javasdk/McpClientHttpFactory.java
+++ b/micronaut-mcp-client-java-sdk/src/main/java/io/micronaut/mcp/client/javasdk/McpClientHttpFactory.java
@@ -28,6 +28,7 @@ import io.modelcontextprotocol.client.McpAsyncClient;
 import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
+import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.json.schema.JsonSchemaValidator;
 import io.modelcontextprotocol.spec.McpSchema;
 import jakarta.inject.Singleton;
@@ -38,11 +39,18 @@ import jakarta.inject.Singleton;
 @Factory
 @Internal
 final class McpClientHttpFactory {
+    private final McpJsonMapper mcpJsonMapper;
+
+    McpClientHttpFactory(McpJsonMapper mcpJsonMapper) {
+        this.mcpJsonMapper = mcpJsonMapper;
+    }
+
     @EachBean(McpClientHttpConfiguration.class)
     @Prototype
     HttpClientStreamableHttpTransport transport(McpClientHttpConfiguration clientHttpConfiguration) {
         return HttpClientStreamableHttpTransport
             .builder(clientHttpConfiguration.getUrl().toString())
+            .jsonMapper(mcpJsonMapper)
             .build();
     }
 

--- a/micronaut-mcp-server-java-sdk/src/main/java/io/micronaut/mcp/server/json/McpSchemaSerdeImport.java
+++ b/micronaut-mcp-server-java-sdk/src/main/java/io/micronaut/mcp/server/json/McpSchemaSerdeImport.java
@@ -101,19 +101,18 @@ import io.modelcontextprotocol.spec.McpSchema.CompleteResult.CompleteCompletion;
 class McpSchemaSerdeImport {
 }
 
-@Mixin.Filter(removeAnnotations = {
-    "com.fasterxml.jackson.annotation.JsonTypeInfo",
-    "com.fasterxml.jackson.annotation.JsonSubTypes",
-    "io.micronaut.serde.config.annotation.SerdeConfig$SerError",
-    "io.micronaut.serde.config.annotation.SerdeConfig$SerSubtyped"
-})
 @JsonInclude(JsonInclude.Include.ALWAYS)
 @Mixin(CompleteCompletion.class)
 class CompleteCompletionMixin {
 
 }
 
-@Mixin.Filter(removeAnnotations = {"com.fasterxml.jackson.annotation.JsonTypeInfo", "io.micronaut.serde.config.annotation.SerdeConfig$SerError"})
+@Mixin.Filter(removeAnnotations = {
+    "com.fasterxml.jackson.annotation.JsonTypeInfo",
+    "com.fasterxml.jackson.annotation.JsonSubTypes",
+    "io.micronaut.serde.config.annotation.SerdeConfig$SerError",
+    "io.micronaut.serde.config.annotation.SerdeConfig$SerSubtyped"
+})
 @Mixin(McpSchema.ResourceContents.class)
 @JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
 class CorrectResourceContentsMixin {

--- a/micronaut-mcp-server-java-sdk/src/main/java/io/micronaut/mcp/server/json/McpSchemaSerdeImport.java
+++ b/micronaut-mcp-server-java-sdk/src/main/java/io/micronaut/mcp/server/json/McpSchemaSerdeImport.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.mcp.server.json;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.micronaut.context.annotation.ClassImport;
 import io.micronaut.context.annotation.Mixin;
@@ -98,7 +99,12 @@ import io.modelcontextprotocol.spec.McpSchema;
 class McpSchemaSerdeImport {
 }
 
-@Mixin.Filter(removeAnnotations = {"com.fasterxml.jackson.annotation.JsonTypeInfo", "io.micronaut.serde.config.annotation.SerdeConfig$SerError"})
+@Mixin.Filter(removeAnnotations = {
+    "com.fasterxml.jackson.annotation.JsonTypeInfo",
+    "com.fasterxml.jackson.annotation.JsonSubTypes",
+    "io.micronaut.serde.config.annotation.SerdeConfig$SerError",
+    "io.micronaut.serde.config.annotation.SerdeConfig$SerSubtyped"
+})
 @Mixin(McpSchema.ResourceContents.class)
 @JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
 class CorrectResourceContentsMixin {
@@ -113,5 +119,7 @@ class CorrectTextResourceContentsMixin {
 @Mixin.Filter(removeAnnotations = {"com.fasterxml.jackson.annotation.JsonTypeInfo", "io.micronaut.serde.config.annotation.SerdeConfig$SerError"})
 @Mixin(McpSchema.BlobResourceContents.class)
 @JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
+@JsonSubTypes({@JsonSubTypes.Type(value = McpSchema.TextResourceContents.class),
+    @JsonSubTypes.Type(value = McpSchema.BlobResourceContents.class)})
 class CorrectBlobResourceContentsMixin {
 }

--- a/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/serialization/ReadResourceResultSerializationTest.java
+++ b/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/serialization/ReadResourceResultSerializationTest.java
@@ -13,8 +13,18 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 class ReadResourceResultSerializationTest {
 
     @Test
-    void serialize(JsonMapper jsonMapper) throws IOException {
-        String json = "{\"contents\":[{\"uri\":\"guidemetadata://micronaut-oauth2-auth0\",\"mimeType\":\"application/json\",\"text\":\"{\\\"title\\\":\\\"Secure a Micronaut application with Auth0\\\",\\\"intro\\\":\\\"Learn how to create a Micronaut application and secure it with an Authorization Server provided by Auth0.\\\",\\\"authors\\\":[\\\"Sergio del Amo\\\"],\\\"tags\\\":[\\\"security-jwt\\\",\\\"security\\\",\\\"authorization-code\\\",\\\"auth0\\\",\\\"graalvm\\\",\\\"thymeleaf\\\",\\\"oauth2\\\",\\\"oidc\\\",\\\"security-oauth2\\\",\\\"yaml\\\"],\\\"category\\\":\\\"Authorization Code\\\",\\\"publicationDate\\\":\\\"2021-09-03\\\",\\\"slug\\\":\\\"micronaut-oauth2-auth0\\\",\\\"url\\\":\\\"https://guides.micronaut.io/latest/micronaut-oauth2-auth0.html\\\",\\\"options\\\":[{\\\"buildTool\\\":\\\"GRADLE\\\",\\\"language\\\":\\\"JAVA\\\",\\\"url\\\":\\\"https://guides.micronaut.io/latest/micronaut-oauth2-auth0-gradle-java.html\\\"},{\\\"buildTool\\\":\\\"GRADLE\\\",\\\"language\\\":\\\"GROOVY\\\",\\\"url\\\":\\\"https://guides.micronaut.io/latest/micronaut-oauth2-auth0-gradle-groovy.html\\\"},{\\\"buildTool\\\":\\\"GRADLE\\\",\\\"language\\\":\\\"KOTLIN\\\",\\\"url\\\":\\\"https://guides.micronaut.io/latest/micronaut-oauth2-auth0-gradle-kotlin.html\\\"},{\\\"buildTool\\\":\\\"MAVEN\\\",\\\"language\\\":\\\"JAVA\\\",\\\"url\\\":\\\"https://guides.micronaut.io/latest/micronaut-oauth2-auth0-maven-java.html\\\"},{\\\"buildTool\\\":\\\"MAVEN\\\",\\\"language\\\":\\\"GROOVY\\\",\\\"url\\\":\\\"https://guides.micronaut.io/latest/micronaut-oauth2-auth0-maven-groovy.html\\\"},{\\\"buildTool\\\":\\\"MAVEN\\\",\\\"language\\\":\\\"KOTLIN\\\",\\\"url\\\":\\\"https://guides.micronaut.io/latest/micronaut-oauth2-auth0-maven-kotlin.html\\\"}]}\"}]}";
+    void serialize(JsonMapper jsonMapper) {
+        //language=JSON
+        String json = """
+            {
+              "contents": [
+                {
+                  "uri": "guidemetadata://micronaut-oauth2-auth0",
+                  "mimeType": "application/json",
+                  "text": "{\\"title\\":\\"Secure a Micronaut application with Auth0\\",\\"intro\\":\\"Learn how to create a Micronaut application and secure it with an Authorization Server provided by Auth0.\\",\\"authors\\":[\\"Sergio del Amo\\"],\\"tags\\":[\\"security-jwt\\",\\"security\\",\\"authorization-code\\",\\"auth0\\",\\"graalvm\\",\\"thymeleaf\\",\\"oauth2\\",\\"oidc\\",\\"security-oauth2\\",\\"yaml\\"],\\"category\\":\\"Authorization Code\\",\\"publicationDate\\":\\"2021-09-03\\",\\"slug\\":\\"micronaut-oauth2-auth0\\",\\"url\\":\\"https://guides.micronaut.io/latest/micronaut-oauth2-auth0.html\\",\\"options\\":[{\\"buildTool\\":\\"GRADLE\\",\\"language\\":\\"JAVA\\",\\"url\\":\\"https://guides.micronaut.io/latest/micronaut-oauth2-auth0-gradle-java.html\\"},{\\"buildTool\\":\\"GRADLE\\",\\"language\\":\\"GROOVY\\",\\"url\\":\\"https://guides.micronaut.io/latest/micronaut-oauth2-auth0-gradle-groovy.html\\"},{\\"buildTool\\":\\"GRADLE\\",\\"language\\":\\"KOTLIN\\",\\"url\\":\\"https://guides.micronaut.io/latest/micronaut-oauth2-auth0-gradle-kotlin.html\\"},{\\"buildTool\\":\\"MAVEN\\",\\"language\\":\\"JAVA\\",\\"url\\":\\"https://guides.micronaut.io/latest/micronaut-oauth2-auth0-maven-java.html\\"},{\\"buildTool\\":\\"MAVEN\\",\\"language\\":\\"GROOVY\\",\\"url\\":\\"https://guides.micronaut.io/latest/micronaut-oauth2-auth0-maven-groovy.html\\"},{\\"buildTool\\":\\"MAVEN\\",\\"language\\":\\"KOTLIN\\",\\"url\\":\\"https://guides.micronaut.io/latest/micronaut-oauth2-auth0-maven-kotlin.html\\"}]}"
+                }
+              ]
+            }""";
         assertDoesNotThrow(() -> jsonMapper.readValue(json, McpSchema.ReadResourceResult.class));
     }
 }

--- a/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/serialization/ReadResourceResultSerializationTest.java
+++ b/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/serialization/ReadResourceResultSerializationTest.java
@@ -1,0 +1,20 @@
+package io.micronaut.mcp.server.serialization;
+
+import io.micronaut.json.JsonMapper;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+@MicronautTest(startApplication = false)
+class ReadResourceResultSerializationTest {
+
+    @Test
+    void serialize(JsonMapper jsonMapper) throws IOException {
+        String json = "{\"contents\":[{\"uri\":\"guidemetadata://micronaut-oauth2-auth0\",\"mimeType\":\"application/json\",\"text\":\"{\\\"title\\\":\\\"Secure a Micronaut application with Auth0\\\",\\\"intro\\\":\\\"Learn how to create a Micronaut application and secure it with an Authorization Server provided by Auth0.\\\",\\\"authors\\\":[\\\"Sergio del Amo\\\"],\\\"tags\\\":[\\\"security-jwt\\\",\\\"security\\\",\\\"authorization-code\\\",\\\"auth0\\\",\\\"graalvm\\\",\\\"thymeleaf\\\",\\\"oauth2\\\",\\\"oidc\\\",\\\"security-oauth2\\\",\\\"yaml\\\"],\\\"category\\\":\\\"Authorization Code\\\",\\\"publicationDate\\\":\\\"2021-09-03\\\",\\\"slug\\\":\\\"micronaut-oauth2-auth0\\\",\\\"url\\\":\\\"https://guides.micronaut.io/latest/micronaut-oauth2-auth0.html\\\",\\\"options\\\":[{\\\"buildTool\\\":\\\"GRADLE\\\",\\\"language\\\":\\\"JAVA\\\",\\\"url\\\":\\\"https://guides.micronaut.io/latest/micronaut-oauth2-auth0-gradle-java.html\\\"},{\\\"buildTool\\\":\\\"GRADLE\\\",\\\"language\\\":\\\"GROOVY\\\",\\\"url\\\":\\\"https://guides.micronaut.io/latest/micronaut-oauth2-auth0-gradle-groovy.html\\\"},{\\\"buildTool\\\":\\\"GRADLE\\\",\\\"language\\\":\\\"KOTLIN\\\",\\\"url\\\":\\\"https://guides.micronaut.io/latest/micronaut-oauth2-auth0-gradle-kotlin.html\\\"},{\\\"buildTool\\\":\\\"MAVEN\\\",\\\"language\\\":\\\"JAVA\\\",\\\"url\\\":\\\"https://guides.micronaut.io/latest/micronaut-oauth2-auth0-maven-java.html\\\"},{\\\"buildTool\\\":\\\"MAVEN\\\",\\\"language\\\":\\\"GROOVY\\\",\\\"url\\\":\\\"https://guides.micronaut.io/latest/micronaut-oauth2-auth0-maven-groovy.html\\\"},{\\\"buildTool\\\":\\\"MAVEN\\\",\\\"language\\\":\\\"KOTLIN\\\",\\\"url\\\":\\\"https://guides.micronaut.io/latest/micronaut-oauth2-auth0-maven-kotlin.html\\\"}]}\"}]}";
+        assertDoesNotThrow(() -> jsonMapper.readValue(json, McpSchema.ReadResourceResult.class));
+    }
+}


### PR DESCRIPTION
This test fails with: 

```
Caused by: io.micronaut.serde.exceptions.SerdeException: Cannot deduct the subtype for bean io.modelcontextprotocol.spec.McpSchema$ResourceContents
```
