### PR TITLE
fix: add JsonInclude Always to CodeCompletion

### DIFF
--- a/micronaut-mcp-server-java-sdk/src/main/java/io/micronaut/mcp/server/json/McpSchemaSerdeImport.java
+++ b/micronaut-mcp-server-java-sdk/src/main/java/io/micronaut/mcp/server/json/McpSchemaSerdeImport.java
@@ -15,12 +15,14 @@
  */
 package io.micronaut.mcp.server.json;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.micronaut.context.annotation.ClassImport;
 import io.micronaut.context.annotation.Mixin;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.serde.annotation.Serdeable;
 import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpSchema.CompleteResult.CompleteCompletion;
 
 @ClassImport(classes = {
     io.modelcontextprotocol.spec.McpSchema.JSONRPCRequest.class,
@@ -83,7 +85,7 @@ import io.modelcontextprotocol.spec.McpSchema;
     io.modelcontextprotocol.spec.McpSchema.CompleteRequest.CompleteArgument.class,
     io.modelcontextprotocol.spec.McpSchema.CompleteRequest.CompleteContext.class,
     io.modelcontextprotocol.spec.McpSchema.CompleteResult.class,
-    io.modelcontextprotocol.spec.McpSchema.CompleteResult.CompleteCompletion.class,
+    CompleteCompletion.class,
     io.modelcontextprotocol.spec.McpSchema.Content.class,
     io.modelcontextprotocol.spec.McpSchema.TextContent.class,
     io.modelcontextprotocol.spec.McpSchema.ImageContent.class,
@@ -96,6 +98,12 @@ import io.modelcontextprotocol.spec.McpSchema;
 }, annotate = Serdeable.class)
 @Internal
 class McpSchemaSerdeImport {
+}
+
+@JsonInclude(JsonInclude.Include.ALWAYS)
+@Mixin(CompleteCompletion.class)
+class CompleteCompletionMixin {
+
 }
 
 @Mixin.Filter(removeAnnotations = {"com.fasterxml.jackson.annotation.JsonTypeInfo", "io.micronaut.serde.config.annotation.SerdeConfig$SerError"})

--- a/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/serialization/CompleteCompletionSerializationTest.java
+++ b/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/serialization/CompleteCompletionSerializationTest.java
@@ -1,0 +1,23 @@
+package io.micronaut.mcp.server.serialization;
+
+import io.micronaut.json.JsonMapper;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@MicronautTest
+class CompleteCompletionSerializationTest {
+
+    @Test
+    void codeCompletionSerialization(JsonMapper jsonMapper) throws IOException {
+        McpSchema.CompleteResult.CompleteCompletion codeComplete = new McpSchema.CompleteResult.CompleteCompletion(Collections.emptyList(), 0, false);
+        String json = jsonMapper.writeValueAsString(codeComplete);
+        String expected = "{\"values\":[],\"total\":0,\"hasMore\":false}";
+        assertEquals(expected, json, json);
+    }
+}


### PR DESCRIPTION
This aims to solve this error when you return an empty completion. The following can be seen in the MCP inspector: 

<img width="830" height="358" alt="CleanShot 2025-10-05 at 19 07 44@2x" src="https://github.com/user-attachments/assets/c7c74043-55a8-473f-aafe-41beb5afe8d9" />
