### PR TITLE
fix: handle resources/templates/list graciously

### DIFF
--- a/micronaut-mcp-server-java-sdk/src/main/java/io/micronaut/mcp/server/exceptions/JsonRrpcResponseUtils.java
+++ b/micronaut-mcp-server-java-sdk/src/main/java/io/micronaut/mcp/server/exceptions/JsonRrpcResponseUtils.java
@@ -32,9 +32,11 @@ import static io.modelcontextprotocol.spec.McpSchema.JSONRPC_VERSION;
 public final class JsonRrpcResponseUtils {
     private static final String HANDLER_FOR_REQUEST_TYPE_PROMPTS_LIST = "Missing handler for request type: prompts/list";
     private static final String HANDLER_FOR_REQUEST_TYPE_RESOURCES_LIST = "Missing handler for request type: resources/list";
+    private static final String HANDLER_FOR_REQUEST_TYPE_RESOURCES_TEMPLATES_LIST = "Missing handler for request type: resources/templates/list";
     private static final String HANDLER_FOR_REQUEST_TYPE_TOOLS_LIST = "Missing handler for request type: tools/list";
     private static final String METHOD_NOT_FOUND_PROMPTS_LIST = "Method not found: prompts/list";
     private static final String METHOD_NOT_FOUND_RESOURCES_LIST = "Method not found: resources/list";
+    private static final String METHOD_NOT_FOUND_RESOURCES_TEMPLATES_LIST = "Method not found: resources/templates/list";
     private static final String METHOD_NOT_FOUND_TOOLS_LIST = "Method not found: tools/list";
 
     private JsonRrpcResponseUtils() {
@@ -63,6 +65,12 @@ public final class JsonRrpcResponseUtils {
                 return new McpSchema.JSONRPCResponse(JSONRPC_VERSION,
                     id,
                     new McpSchema.ListResourcesResult(Collections.emptyList(), null), null);
+            }
+            case HANDLER_FOR_REQUEST_TYPE_RESOURCES_TEMPLATES_LIST -> {
+                Object id = jsonrpcMessage instanceof McpSchema.JSONRPCRequest jsonrpcRequest ? jsonrpcRequest.id() : null;
+                return new McpSchema.JSONRPCResponse(JSONRPC_VERSION,
+                    id,
+                    new McpSchema.ListResourceTemplatesResult(Collections.emptyList(), null), null);
             }
             case HANDLER_FOR_REQUEST_TYPE_TOOLS_LIST -> {
                 Object id = jsonrpcMessage instanceof McpSchema.JSONRPCRequest jsonrpcRequest ? jsonrpcRequest.id() : null;
@@ -101,6 +109,9 @@ public final class JsonRrpcResponseUtils {
             case METHOD_NOT_FOUND_RESOURCES_LIST -> new McpSchema.JSONRPCResponse(JSONRPC_VERSION,
                 jsonrpcResponse.id(),
                 new McpSchema.ListResourcesResult(Collections.emptyList(), null), null);
+            case METHOD_NOT_FOUND_RESOURCES_TEMPLATES_LIST -> new McpSchema.JSONRPCResponse(JSONRPC_VERSION,
+                jsonrpcResponse.id(),
+                new McpSchema.ListResourceTemplatesResult(Collections.emptyList(), null), null);
             case METHOD_NOT_FOUND_TOOLS_LIST -> new McpSchema.JSONRPCResponse(JSONRPC_VERSION,
                 jsonrpcResponse.id(),
                 new McpSchema.ListToolsResult(Collections.emptyList(), null), null);

--- a/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/stateless/sync/resources/ResourcesTemplatesNoResourcesCapabilityTest.java
+++ b/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/stateless/sync/resources/ResourcesTemplatesNoResourcesCapabilityTest.java
@@ -1,0 +1,39 @@
+package io.micronaut.mcp.server.stateless.sync.resources;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.client.BlockingHttpClient;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+@Property(name = "micronaut.mcp.server.info.name", value="test mcp server")
+@Property(name = "micronaut.mcp.server.info.version", value="0.0.1")
+@Property(name = "micronaut.mcp.server.transport", value = "HTTP")
+@MicronautTest
+class ResourcesTemplatesNoResourcesCapabilityTest {
+    public static final String RESOURCES_TEMPLATES_LIST = """
+        {"jsonrpc": "2.0","id": 1,"method":"resources/templates/list"}""";
+    public static final String RESOURCES_TEMPLATES_LIST_RESULT = """
+{"jsonrpc": "2.0","id": 1,"result": {"resourceTemplates":[]}}""";
+
+    /**
+     * Even if the server does not have the resource capabilities, clients may not respect that and send a resources/templates/list request.
+     * In that scenario, the server should return an empty list of resources
+     * @param httpClient HTTP Client
+     * @throws JSONException JSON Exception
+     */
+    @Test
+    void testResourcesTemplatesList(@Client("/") HttpClient httpClient) throws JSONException {
+        BlockingHttpClient client = httpClient.toBlocking();
+        HttpRequest<?> req = HttpRequest.POST("/mcp", RESOURCES_TEMPLATES_LIST);
+        String jsonRpc = assertDoesNotThrow(() -> client.retrieve(req));
+        String expected = RESOURCES_TEMPLATES_LIST_RESULT;
+        JSONAssert.assertEquals(expected, jsonRpc, true);
+    }
+}

--- a/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/stdio/sync/StdioResourcesListNoResourcesTemplatesCapabilityTest.java
+++ b/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/stdio/sync/StdioResourcesListNoResourcesTemplatesCapabilityTest.java
@@ -1,0 +1,77 @@
+package io.micronaut.mcp.server.stdio.sync;
+
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Prototype;
+import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.mcp.server.stdio.StdioServerTransportProviderReplacement;
+import io.micronaut.mcp.server.utils.Stdio;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.spec.McpServerTransportProvider;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Inject;
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static io.micronaut.mcp.server.utils.JsonRpcMessages.INITIALIZE;
+import static io.micronaut.mcp.server.utils.JsonRpcMessages.INITIALIZED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Property(name = "micronaut.mcp.server.info.name", value="test mcp server")
+@Property(name = "micronaut.mcp.server.info.version", value="0.0.1")
+@Property(name = "micronaut.mcp.server.transport", value = "STDIO")
+@Property(name = "spec.name", value = "StdioResourcesListNoResourcesTemplatesCapabilityTest")
+@MicronautTest
+class StdioResourcesListNoResourcesTemplatesCapabilityTest {
+    public static final String RESOURCES_TEMPLATES_LIST = """
+        {"jsonrpc": "2.0","id": 1,"method":"resources/templates/list"}""";
+    public static final String RESOURCES_TEMPLATES_LIST_RESULT = """
+{"jsonrpc": "2.0","id": 1,"result": {"resourceTemplates":[]}}""";
+
+    @Inject
+    ReplacementMcpServerTransportProviderFactory factory;
+
+    /**
+     * Even if the server does not have the prompts capabilities, clients may not respect that and send a prompts/list request.
+     * In that scenario, the server should return an empty list of prompts
+     */
+    @SuppressWarnings("java:S2925")
+    @Test
+    void syncResourceTemplates() throws IOException, InterruptedException, JSONException {
+        factory.stdio.sendRequest(INITIALIZE);
+        Thread.sleep(TimeUnit.SECONDS.toMillis(1));
+        factory.stdio.sendRequest(INITIALIZED);
+        Thread.sleep(TimeUnit.SECONDS.toMillis(1));
+        factory.stdio.sendRequest(RESOURCES_TEMPLATES_LIST);
+        Thread.sleep(TimeUnit.SECONDS.toMillis(1));
+        List<String> responses = factory.stdio.readResponses();
+        assertEquals(2, responses.size());
+        String readJsonRpc = responses.get(1);
+        JSONAssert.assertEquals(RESOURCES_TEMPLATES_LIST_RESULT, readJsonRpc, true);
+    }
+
+    @Requires(property = "spec.name", value = "StdioResourcesListNoResourcesTemplatesCapabilityTest")
+    @Factory
+    static class ReplacementMcpServerTransportProviderFactory implements AutoCloseable {
+        public final Stdio stdio = new Stdio();
+
+        @Prototype
+        @Replaces(McpServerTransportProvider.class)
+        McpServerTransportProvider stdioServerTransportProviderReplacement(McpJsonMapper jsonMapper) {
+            return new StdioServerTransportProviderReplacement(jsonMapper, stdio.serverStdin, stdio.serverStdout);
+        }
+
+        @PreDestroy
+        @Override
+        public void close() throws IOException {
+            stdio.close();
+        }
+    }
+}


### PR DESCRIPTION
Related to #72

Some clients will do resources/templates/list even if the capabilities of the server don’t include resources. This change handles those requests graciously.