### PR TITLE
fix(build): update testFramework to JUnit 6

### DIFF
--- a/micronaut-mcp-client-java-sdk/build.gradle.kts
+++ b/micronaut-mcp-client-java-sdk/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
     testImplementation(projects.testSuiteMoon)
 }
 micronautBuild {
-    testFramework = TestFramework.JUNIT5
+    testFramework = TestFramework.JUNIT6
 }
 tasks.withType<Test> {
     useJUnitPlatform()

--- a/micronaut-mcp-client-langchain4j/build.gradle.kts
+++ b/micronaut-mcp-client-langchain4j/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
     testImplementation(projects.testSuiteMoon)
 }
 micronautBuild {
-    testFramework = TestFramework.JUNIT5
+    testFramework = TestFramework.JUNIT6
 }
 tasks.withType<Test> {
     useJUnitPlatform()

--- a/micronaut-mcp-server-java-sdk/build.gradle.kts
+++ b/micronaut-mcp-server-java-sdk/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     testImplementation(mnTest.junit.jupiter.params)
 }
 micronautBuild {
-    testFramework = TestFramework.JUNIT5
+    testFramework = TestFramework.JUNIT6
 }
 tasks.withType<Test> {
     useJUnitPlatform()

--- a/micronaut-mcp-server-java-sdk/src/main/java/io/micronaut/mcp/server/json/McpSchemaSerdeImport.java
+++ b/micronaut-mcp-server-java-sdk/src/main/java/io/micronaut/mcp/server/json/McpSchemaSerdeImport.java
@@ -33,6 +33,8 @@ import io.modelcontextprotocol.spec.McpSchema.CompleteResult.CompleteCompletion;
     io.modelcontextprotocol.spec.McpSchema.ClientCapabilities.RootCapabilities.class,
     io.modelcontextprotocol.spec.McpSchema.ClientCapabilities.Sampling.class,
     io.modelcontextprotocol.spec.McpSchema.ClientCapabilities.Elicitation.class,
+    io.modelcontextprotocol.spec.McpSchema.ClientCapabilities.Elicitation.Form.class,
+    io.modelcontextprotocol.spec.McpSchema.ClientCapabilities.Elicitation.Url.class,
     io.modelcontextprotocol.spec.McpSchema.ServerCapabilities.class,
     io.modelcontextprotocol.spec.McpSchema.ServerCapabilities.CompletionCapabilities.class,
     io.modelcontextprotocol.spec.McpSchema.ServerCapabilities.LoggingCapabilities.class,

--- a/micronaut-mcp/build.gradle.kts
+++ b/micronaut-mcp/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
     testRuntimeOnly(mnLogging.logback.classic)
 }
 micronautBuild {
-    testFramework = TestFramework.JUNIT5
+    testFramework = TestFramework.JUNIT6
 }
 tasks.withType<Test> {
     useJUnitPlatform()

--- a/test-suite-mcp-http-tck/build.gradle.kts
+++ b/test-suite-mcp-http-tck/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
     implementation(libs.jsonassert)
 }
 micronautBuild {
-    testFramework = TestFramework.JUNIT5
+    testFramework = TestFramework.JUNIT6
 }
 tasks.withType<Test> {
     useJUnitPlatform()


### PR DESCRIPTION
This PR updates the testFramework from the previous version to **JUnit 6** to ensure the project builds successfully both locally and in CI/CD environments using [micronaut-build 8.0.x](https://github.com/micronaut-projects/micronaut-build/blob/8.0.x/micronaut-gradle-plugins/src/main/java/io/micronaut/build/TestFramework.java#L20)
