### PR TITLE
change McpSchema.Role serialization

### DIFF
--- a/micronaut-mcp-server-java-sdk/src/main/java/io/micronaut/mcp/server/json/McpSchemaRoleSerde.java
+++ b/micronaut-mcp-server-java-sdk/src/main/java/io/micronaut/mcp/server/json/McpSchemaRoleSerde.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.mcp.server.json;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Deserializer;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.Serializer;
+import io.micronaut.serde.util.NullableDeserializer;
+import io.modelcontextprotocol.spec.McpSchema;
+import jakarta.inject.Singleton;
+
+import java.io.IOException;
+
+@Singleton
+@Internal
+final class McpSchemaRoleSerde implements Serializer<McpSchema.Role>, NullableDeserializer<McpSchema.Role> {
+
+    @Override
+    public void serialize(Encoder encoder,
+                          Serializer.EncoderContext context,
+                          Argument<? extends McpSchema.Role> type,
+                          McpSchema.Role value) throws IOException {
+        if (value == null) {
+            encoder.encodeNull();
+            return;
+        }
+        encoder.encodeString(switch (value) {
+            case USER -> "user";
+            case ASSISTANT -> "assistant";
+        });
+    }
+
+    @Override
+    public McpSchema.Role deserializeNonNull(Decoder decoder,
+                                             Deserializer.DecoderContext context,
+                                             Argument<? super McpSchema.Role> type) throws IOException {
+        return switch (decoder.decodeString()) {
+            case "user", "USER" -> McpSchema.Role.USER;
+            case "assistant", "ASSISTANT" -> McpSchema.Role.ASSISTANT;
+            default -> throw decoder.createDeserializationException("Invalid role value", type);
+        };
+    }
+}

--- a/micronaut-mcp-server-java-sdk/src/main/java/io/micronaut/mcp/server/json/McpSchemaSerdeImport.java
+++ b/micronaut-mcp-server-java-sdk/src/main/java/io/micronaut/mcp/server/json/McpSchemaSerdeImport.java
@@ -42,7 +42,6 @@ import io.modelcontextprotocol.spec.McpSchema.CompleteResult.CompleteCompletion;
     io.modelcontextprotocol.spec.McpSchema.ServerCapabilities.ResourceCapabilities.class,
     io.modelcontextprotocol.spec.McpSchema.ServerCapabilities.ToolCapabilities.class,
     io.modelcontextprotocol.spec.McpSchema.Implementation.class,
-    io.modelcontextprotocol.spec.McpSchema.Role.class,
     io.modelcontextprotocol.spec.McpSchema.Annotations.class,
     io.modelcontextprotocol.spec.McpSchema.Resource.class,
     io.modelcontextprotocol.spec.McpSchema.ResourceTemplate.class,

--- a/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/serialization/RoleSerializationTest.java
+++ b/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/serialization/RoleSerializationTest.java
@@ -1,0 +1,26 @@
+package io.micronaut.mcp.server.serialization;
+
+import io.micronaut.json.JsonMapper;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@MicronautTest(startApplication = false)
+class RoleSerializationTest {
+
+    @Test
+    void roleSerialization(JsonMapper jsonMapper) throws IOException {
+        String json = jsonMapper.writeValueAsString(McpSchema.Role.USER);
+        assertEquals("\"user\"", json);
+    }
+
+    @Test
+    void roleDeserialization(JsonMapper jsonMapper) throws IOException {
+        McpSchema.Role role = jsonMapper.readValue("\"assistant\"", McpSchema.Role.class);
+        assertEquals(McpSchema.Role.ASSISTANT, role);
+    }
+}

--- a/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/serialization/RoleSerializationTest.java
+++ b/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/serialization/RoleSerializationTest.java
@@ -3,7 +3,10 @@ package io.micronaut.mcp.server.serialization;
 import io.micronaut.json.JsonMapper;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import io.modelcontextprotocol.spec.McpSchema;
+import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 
@@ -11,16 +14,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @MicronautTest(startApplication = false)
 class RoleSerializationTest {
+    @Inject
+    JsonMapper jsonMapper;
 
     @Test
-    void roleSerialization(JsonMapper jsonMapper) throws IOException {
+    void roleSerialization() throws IOException {
         String json = jsonMapper.writeValueAsString(McpSchema.Role.USER);
         assertEquals("\"user\"", json);
     }
 
-    @Test
-    void roleDeserialization(JsonMapper jsonMapper) throws IOException {
-        McpSchema.Role role = jsonMapper.readValue("\"assistant\"", McpSchema.Role.class);
+    @ParameterizedTest
+    @ValueSource(strings = {"assistant", "ASSISTANT"})
+    void roleDeserialization(String input) throws IOException {
+        McpSchema.Role role = jsonMapper.readValue("\"" + input + "\"", McpSchema.Role.class);
         assertEquals(McpSchema.Role.ASSISTANT, role);
     }
 }


### PR DESCRIPTION
> The failure happens because McpSchema.Role was being re-annotated for Serde codegen in McpSchemaSerdeImport even though it already comes from the MCP SDK path, so Micronaut Serde tries to generate SerdeMcpSchema_RoleSerializer repeatedly and javac throws “Output stream or writer has already been opened.” I removed McpSchema.Role.class from that @ClassImport list, then preserved MCP’s lowercase wire format by adding an explicit local serde for Role (user/assistant),