### PR TITLE
Update to Micronaut M20

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@
 # a managed version (a version which alias starts with "managed-"
 
 [versions]
-micronaut = "5.0.0-M18"
+micronaut = "5.0.0-M19"
 micronaut-test = "5.0.0-M7"
 micronaut-platform = "4.10.10"
 micronaut-security = "5.0.0-M1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,12 +16,12 @@
 # a managed version (a version which alias starts with "managed-"
 
 [versions]
-micronaut = "5.0.0-M17"
+micronaut = "5.0.0-M18"
 micronaut-test = "5.0.0-M7"
-micronaut-platform = "4.10.8"
+micronaut-platform = "4.10.10"
 micronaut-security = "5.0.0-M1"
-micronaut-serde = "3.0.0-M3"
-micronaut-json-schema = "2.0.0-M7"
+micronaut-serde = "3.0.0-M5"
+micronaut-json-schema = "2.0.0-M8"
 micronaut-langchain4j = "2.0.0-M1"
 micronaut-validation = "5.0.0-M1"
 managed-mcp-java-sdk = "1.1.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,11 +16,11 @@
 # a managed version (a version which alias starts with "managed-"
 
 [versions]
-micronaut = "5.0.0-M19"
+micronaut = "5.0.0-M20"
 micronaut-test = "5.0.0-M7"
 micronaut-platform = "4.10.10"
 micronaut-security = "5.0.0-M1"
-micronaut-serde = "3.0.0-M5"
+micronaut-serde = "3.0.0-M6"
 micronaut-json-schema = "2.0.0-M8"
 micronaut-langchain4j = "2.0.0-M1"
 micronaut-validation = "5.0.0-M1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ micronaut-serde = "3.0.0-M5"
 micronaut-json-schema = "2.0.0-M8"
 micronaut-langchain4j = "2.0.0-M1"
 micronaut-validation = "5.0.0-M1"
-managed-mcp-java-sdk = "1.1.0"
+managed-mcp-java-sdk = "1.1.1"
 jsonassert = "1.5.3"
 micronaut-gradle-plugin = "4.6.2"
 

--- a/micronaut-mcp-server-java-sdk/src/main/java/io/micronaut/mcp/server/exceptions/InvalidFormatExceptionMcpErrorMapper.java
+++ b/micronaut-mcp-server-java-sdk/src/main/java/io/micronaut/mcp/server/exceptions/InvalidFormatExceptionMcpErrorMapper.java
@@ -47,7 +47,7 @@ class InvalidFormatExceptionMcpErrorMapper implements McpErrorExceptionMapper<In
     private static String conciseMessage(InvalidFormatException e) {
         String path = e.getPath() == null || e.getPath().isEmpty() ? "" :
             e.getPath().stream()
-                .map(ref -> ref.getFieldName() != null ? ref.getFieldName() : ("[" + ref.getIndex() + "]"))
+                .map(ref -> ref.getPropertyName() != null ? ref.getPropertyName() : ("[" + ref.getIndex() + "]"))
                 .collect(Collectors.joining("."));
         String value = String.valueOf(e.getValue());
         if (!path.isEmpty()) {


### PR DESCRIPTION
- Update to Micronaut M18 and serde M5
- Update to mcp sdk 1.1.1
- Fix `InvalidFormatExceptionMcpErrorMapper` to use Jackson 3's `Reference#getPropertyName()` instead of the removed `getFieldName()` API.
