### PR TITLE
Fix invalid JSON Schema type `bool` → `boolean` for boolean tool arguments

### DIFF
--- a/micronaut-mcp-server-java-sdk/src/main/java/io/micronaut/mcp/server/registry/JsonSchemaUtils.java
+++ b/micronaut-mcp-server-java-sdk/src/main/java/io/micronaut/mcp/server/registry/JsonSchemaUtils.java
@@ -26,7 +26,7 @@ final class JsonSchemaUtils {
     public static final String TYPE_NUMBER = "number";
     public static final String TYPE_OBJECT = "object";
     public static final String TYPE_ARRAY = "array";
-    public static final String TYPE_BOOL = "bool";
+    public static final String TYPE_BOOL = "boolean";
     public static final String TYPE_NULL = "null";
 
     private JsonSchemaUtils() {

--- a/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/utils/JsonRpcMessages.java
+++ b/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/utils/JsonRpcMessages.java
@@ -210,7 +210,7 @@ public final class JsonRpcMessages {
     public static final String EXPECTED_TOOLS_CALL_OBJECT_RETURN = "{\"jsonrpc\":\"2.0\",\"id\":4,\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"{\\\"fen\\\":\\\"r1bqk2r/ppp2ppp/2n5/1BbpP3/3Nn3/8/PPP2PPP/RNBQK2R w KQkq - 1 8\\\",\\\"evaluation\\\":\\\"+0.12\\\"}\"}],\"isError\":false,\"structuredContent\":{\"evaluation\":\"+0.12\",\"fen\":\"r1bqk2r/ppp2ppp/2n5/1BbpP3/3Nn3/8/PPP2PPP/RNBQK2R w KQkq - 1 8\"}}}";
 
     public static final String EXPECTED_TOOLS_LIST_WITH_TOOL_ARGS = """
-        {"jsonrpc":"2.0","id":3,"result":{"tools":[{"name":"fenEvaluation","description":"Evaluate a chess position using a FEN string.","inputSchema":{"type":"object","properties":{"tetWrLong":{"type":"number"},"fenList":{"type":"array"},"testReq":{"type":"object"},"tetBol":{"type":"bool"},"tetLong":{"type":"number"},"fen":{"type":"string"},"tetWrBol":{"type":"bool"}},"required":["fen","fenList","tetBol","tetWrBol","tetLong","tetWrLong","testReq"]}}]}}""";
+        {"jsonrpc":"2.0","id":3,"result":{"tools":[{"name":"fenEvaluation","description":"Evaluate a chess position using a FEN string.","inputSchema":{"type":"object","properties":{"tetWrLong":{"type":"number"},"fenList":{"type":"array"},"testReq":{"type":"object"},"tetBol":{"type":"boolean"},"tetLong":{"type":"number"},"fen":{"type":"string"},"tetWrBol":{"type":"boolean"}},"required":["fen","fenList","tetBol","tetWrBol","tetLong","tetWrLong","testReq"]}}]}}""";
 
     public static final String EXPECTED_TOOLS_LIST = """
         {"jsonrpc":"2.0","id":3,"result":{"tools":[{"name":"fenEvaluation","description":"Evaluate a chess position using a FEN string.","inputSchema":{"type":"object","properties":{"fen":{"type":"string"}},"required":["fen"]}}]}}""";


### PR DESCRIPTION
## Problem

A tool method that declares a `boolean` (or `Boolean`) argument generates an
`inputSchema` whose property type is `"bool"`:

```json
"tetBol": { "type": "bool" }
```

`"bool"` is not a valid JSON Schema type — [the spec](https://json-schema.org/understanding-json-schema/reference/type)
defines `"boolean"`. As a result, any tool with a boolean argument produces an
invalid input schema, which strict MCP clients / schema validators reject.

## Root cause

`JsonSchemaUtils.TYPE_BOOL` was set to `"bool"`:

```java
public static final String TYPE_BOOL = "bool";
```

`ToolRegistry.argumentType()` maps `Boolean.class` to this constant, so the
wrong literal ends up in the generated schema. (The Javadoc directly above the
constant links the JSON Schema type reference, which lists `boolean`.)

## Fix

Change the constant to the spec-valid `"boolean"`. One-line source change.

## Test

`StatelessSyncToolsArgParametersTest` already exercises a tool with both a
primitive `boolean` and a boxed `Boolean` argument; its expected fixture
(`JsonRpcMessages.EXPECTED_TOOLS_LIST_WITH_TOOL_ARGS`) previously asserted
`"type":"bool"`. Updated the fixture to `"type":"boolean"`, so the test now
locks in the correct, spec-valid output and would catch a regression.
