### PR TITLE
Select MCP stdio application by transport

### DIFF
--- a/micronaut-mcp-server-java-sdk/src/main/java/io/micronaut/mcp/server/stdio/McpStdioApplication.java
+++ b/micronaut-mcp-server-java-sdk/src/main/java/io/micronaut/mcp/server/stdio/McpStdioApplication.java
@@ -29,10 +29,10 @@ import io.micronaut.runtime.exceptions.ApplicationStartupException;
 import jakarta.inject.Singleton;
 
 /**
- * An alternative {@link EmbeddedApplication} that gets activated for MCP Server using stdio transport when no other application is present.
+ * An alternative {@link EmbeddedApplication} that gets activated for MCP Server using stdio transport.
  */
 @Singleton
-@Requires(missingBeans = EmbeddedApplication.class)
+@Requires(property = McpServerConfiguration.PROPERTY_TRANSPORT, value = McpServerConfiguration.TRANSPORT_STDIO)
 @Internal
 final class McpStdioApplication implements EmbeddedApplication<McpStdioApplication>, Described {
 
@@ -106,4 +106,3 @@ final class McpStdioApplication implements EmbeddedApplication<McpStdioApplicati
         return mcpServerConfiguration.getTransport() + " " + (mcpServerConfiguration.isReactive() ? "async" : "sync");
     }
 }
-

--- a/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/stdio/McpStdioApplicationTest.java
+++ b/micronaut-mcp-server-java-sdk/src/test/java/io/micronaut/mcp/server/stdio/McpStdioApplicationTest.java
@@ -22,4 +22,22 @@ class McpStdioApplicationTest {
             assertDoesNotThrow(app::close);
         }
     }
+
+    @Test
+    void testStdioApplicationIsSelectedByTransport() {
+        try (ApplicationContext ctx = ApplicationContext.run(Map.of(
+            McpServerConfiguration.PROPERTY_TRANSPORT,
+            McpServerConfiguration.TRANSPORT_STDIO))) {
+            assertTrue(ctx.containsBean(McpStdioApplication.class));
+        }
+    }
+
+    @Test
+    void testStdioApplicationIsNotSelectedForHttpTransport() {
+        try (ApplicationContext ctx = ApplicationContext.run(Map.of(
+            McpServerConfiguration.PROPERTY_TRANSPORT,
+            McpServerConfiguration.TRANSPORT_HTTP))) {
+            assertFalse(ctx.containsBean(McpStdioApplication.class));
+        }
+    }
 }


### PR DESCRIPTION
Select the embedded MCP stdio application from the configured transport instead of using bean absence as the selector. This keeps stdio and HTTP application modes mutually exclusive.

Tests:
`./gradlew :micronaut-mcp-server-java-sdk:test --tests io.micronaut.mcp.server.stdio.McpStdioApplicationTest --rerun-tasks --stacktrace`